### PR TITLE
Import additional documentation from internal wiki

### DIFF
--- a/SIGNALS.md
+++ b/SIGNALS.md
@@ -1,0 +1,87 @@
+
+Flux supports using SWF's workflow signaling mechanism to affect the behavior of a running workflow in a few specific ways.
+
+To send a signal, the `SignalName` field in the SWF `SignalWorkflowExecution` request should be the name of the signal exactly as documented below, and the input to the signal should be a map of input attributes, in json format, containing the attributes required for that signal. Since these signals are typically sent from a UI (such as an operational console or the AWS Management Console), or via CLI commands, and since these signals are not normally useful except for extraordinary operational needs, the FluxCapacitor interface does not provide a way to send these signals from within your application.
+
+All signals require, as one of their inputs, a field named `activityId`, which should match the activity id of the *next* execution of the step. This will match the id of the open retry timer. For example, if a step is named `EatSandwich`, and the fifth retry of the step is scheduled, there will be an open timer with the id `EatSandwich_5`, and when that step actually executes again, that activity's id will be `EatSandwich_5`.
+
+Delay Retry
+-----------
+
+This signal tells Flux to cancel the current retry timer and reschedule it with the specified delay (in seconds). The new timer will be set to exactly the delay time provided, with no jitter or other modifications applied to it.
+
+Signal name: `DelayRetry`
+
+Example input:
+```json
+{
+  "activityId": "EatSandwich_5",
+  "delayInSeconds": 543
+}
+```
+
+Retry Now
+---------
+
+This signal tells Flux to cancel the current retry timer and reschedule the step immediately. This is functionally equivalent to sending the DelayRetry signal with a delay of 0 seconds.
+
+Signal name: `RetryNow`
+
+Example input:
+```json
+{
+  "activityId": "EatSandwich_5"
+}
+```
+
+Force Result
+------------
+
+This signal tells flux to cancel the current retry timer and pretend the step completed with the specified result code. Note that if your graph does not define a transition for that result code, your workflow will get stuck; to fix this, send another ForceResult signal with the same activityId containing a result code that your graph //does// define a transition for.
+
+The two default result codes are `_succeed` and `_fail`, but you may specify any result code defined by your workflow graph.
+
+This is most useful for forcing a workflow into a rollback path.
+
+Signal name: `ForceResult`
+
+Example input:
+```json
+{
+  "activityId": "EatSandwich_5",
+  "resultCode": "_fail"
+}
+```
+
+Note that if you send this signal to a partitioned step, the result code applies only to that specific partition; also note that partitioned steps only support the two default result codes.
+
+To aid in building tools that can send the Force Result signal, Flux populates the workflow's execution context (accessible via the `latestExecutionContext` field in the response to the SWF `DescribeWorkflowExecution` API) with the list of step result codes that the workflow graph defines for the current step, as well as information about which step each of those result codes will cause the workflow to transition to.
+
+The execution context will be a json object as follows:
+
+```json
+{
+  "_nextStepName": "\"EatSandwich\"",
+  "_nextStepSupportedResultCodes": "<result code map>"
+}
+```
+
+`_nextStepName` indicates which step the workflow will run next (keeping in mind that this value is set at the same time as the next step is scheduled). For implementation reasons, the string is double-encoded.
+
+`_nextStepSupportedResultCodes` is itself a json object (encoded into a string) that (when decoded) looks like this:
+
+```json
+{
+  "_succeed": "DrinkWater",
+  "_fail": "ThrowAwayBadSandwich"
+}
+``` 
+
+All together, the execution context for this example would be:
+
+```json
+{
+  "_nextStepName": "\"EatSandwich\"",
+  "_nextStepSupportedResultCodes": "{\"_succeed\":\"DrinkWater\",\"_fail\":\"ThrowAwayBadSandwich\"}"
+}
+```

--- a/flux-common/src/main/java/software/amazon/aws/clients/swf/flux/step/PartitionIdGenerator.java
+++ b/flux-common/src/main/java/software/amazon/aws/clients/swf/flux/step/PartitionIdGenerator.java
@@ -22,11 +22,17 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Tells FluxCapacitor which method should be called to generate the partition IDs used for a particular partitioned workflow step.
+ * Tells Flux which method should be called to generate the partition IDs used for a particular partitioned workflow step.
  * Exactly one method should have this annotation for any class implementing the PartitionedWorkflowStep interface.
- * Every parameter of the method should also have the @Attribute annotation.
+ * Parameters to this method have the same annotation requirements as parameters to @StepApply methods.
  *
- * The return type of the method *must* be List&lt;String&gt;. The values in the list are used as the partition ids.
+ * The return type of the method must be either List&lt;String&gt; or PartitionIdGeneratorResult.
+ * The partition IDs are taken from the provided response object.
+ *
+ * A maximum of 1000 partition IDs may be returned. This is due to SWF's hard limit on the number of decisions that
+ * can be returned as part of a decision task response.
+ *
+ * If the annotated method throws an exception, Flux will fail the entire decision task and try again.
  */
 @Target({ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)

--- a/flux-common/src/main/java/software/amazon/aws/clients/swf/flux/step/PartitionedWorkflowStep.java
+++ b/flux-common/src/main/java/software/amazon/aws/clients/swf/flux/step/PartitionedWorkflowStep.java
@@ -20,7 +20,11 @@ package software.amazon.aws.clients.swf.flux.step;
  * An interface marking a class to be a *partitioned* workflow step.
  * As with WorkflowStep, the class must define exactly one public method with the @StepApply annotation.
  *
- * In addition, the step must implement a method with the @PartitionIdGenerator annotation.
+ * A partitioned workflow step is a step where multiple copies of the step are executed in parallel with slightly different
+ * input. For example, an order validation workflow might include a step that validates item availability for each
+ * item in parallel, where each partition handles a single item.
+ *
+ * Any step that implements this interface must implement a method with the @PartitionIdGenerator annotation.
  *
  * PartitionedWorkflowSteps may override declaredOutputAttributes to declare that their @PartitionIdGenerator method
  * returns the declared attributes. If their @StepApply method includes any output attributes they are ignored.
@@ -33,9 +37,22 @@ package software.amazon.aws.clients.swf.flux.step;
  * to be provided the number of partitions that were created.
  *
  * Partition result codes are handled as follows:
- * - FAILURE: the entire step is failed if a single partition fails. Partitions that are already scheduled may or may not execute.
+ * - FAILURE: the entire step is failed if a single partition fails. Other partitions will continue to retry until
+ *            they either succeed or fail.
  * - SUCCESS: the step does not succeed until all of its partitions have succeeded.
  * - RETRY: each partition will retry as needed until it succeeds or fails.
+ *
+ * Custom result codes are specifically disallowed for partitioned workflow steps.
+ *
+ * Do not attempt to convert an existing step from PartitionedWorkflowStep to WorkflowStep, or vice versa; this would
+ * result in an invalid workflow state.
+ *
+ * If it is important to use the same set of partition IDs for multiple steps in a workflow, there are two solutions,
+ * depending on the nature of the partition IDs:
+ * - If the partition IDs are static (or won't change during the workflow), the same partition ID generation code can be used,
+ *   either via a utility method or by sharing a base class between the steps in question.
+ * - If the calculated set of partition IDs can change from one execution to another, then the workflow should determine
+ *   the set of partition IDs once and store them elsewhere for lookup in the @PartitionIdGenerator methods.
  */
 public interface PartitionedWorkflowStep extends WorkflowStep {
 }

--- a/flux-common/src/main/java/software/amazon/aws/clients/swf/flux/step/StepHook.java
+++ b/flux-common/src/main/java/software/amazon/aws/clients/swf/flux/step/StepHook.java
@@ -26,15 +26,15 @@ import java.lang.annotation.Target;
  *
  * The parameters of the method should have the @Attribute annotation.
  *
- * A small number of attributes are available to hooks in addition to the attributes from the running workflow:
- * - StepAttributes.WORKFLOW_ID - The unique identifier of this workflow execution,
- *                                i.e. what was passed to FluxCapacitor.executeWorkflow. This must be a String.
- * - StepAttributes.ACTIVITY_NAME - The name of this activity (in the format {workflow-name}.{step-name}). This must be a String.
- *
- * POST hooks may also request the StepAttributes.RESULT_CODE and StepAttributes.ACTIVITY_COMPLETION_MESSAGE attributes;
- * they will both be null if the step is going to retry. Both are Strings.
+ * See WorkflowStepHook for more information on when methods with the @StepHook annotation are called.
  *
  * The hook is run every time the hooked step is run and should therefore be idempotent.
+ *
+ * If the hook throws an exception, Flux checks the retryOnFailure field, which defaults to false.
+ * If it is false, then Flux logs the exception and proceeds to execute the step as normal
+ * (or mark the execution as finished, if it's a POST hook).
+ * Otherwise, Flux handles the exception the same way it would handle it if it had been thrown by the @StepApply method;
+ * specifically, it causes the entire step to retry. The subsequent attempt will execute all hooks again, as normal.
  *
  * The return value of the method is logged but otherwise ignored, so the return type does not matter.
  */

--- a/flux-common/src/main/java/software/amazon/aws/clients/swf/flux/step/StepResult.java
+++ b/flux-common/src/main/java/software/amazon/aws/clients/swf/flux/step/StepResult.java
@@ -27,6 +27,30 @@ import java.util.Set;
 /**
  * A container object for passing around the results of a workflow step,
  * including whether it succeeded and any attributes that should be passed along to the next step.
+ *
+ * Output attributes may be of any type allowed by Flux as input attributes;
+ * see software.amazon.aws.clients.swf.flux.step.Attribute for more information.
+ *
+ * Output attributes provided by partitioned steps are ignored.
+ *
+ * Output attributes overwrite existing attributes if there is a name conflict.
+ * This should be done sparingly if at all, since it complicates debugging.
+ *
+ * The SWF API field used by Flux to store attributes has a maximum size enforced by SWF. Step attributes should
+ * be used only to store small pieces of metadata that are not needed beyond the lifetime of the workflow.
+ * If the attributes output by a step make the attribute map too large, the step will retry indefinitely
+ * until the code is updated to return smaller or fewer attributes in the step result.
+ *
+ * For convenience, Flux provides two additional attributes in the metadata for the SWF ActivityTaskCompleted event:
+ * - "_result_code": String
+ *   The result code returned by the step.
+ * - "_activity_completion_message": String
+ *   The message included in the StepResult, i.e. the string in StepResult.success("Completion message here");
+ *
+ * The two-parameter overloads of StepResult.success() and StepResult.failure() allow the definition of custom
+ * result codes for the step. These result codes can be used with WorkflowGraphBuilder to define branching paths
+ * through a workflow's steps. For example, a series of rollback steps may be define which can unwind
+ * a partially-applied operation.
  */
 public final class StepResult {
 

--- a/flux-common/src/main/java/software/amazon/aws/clients/swf/flux/step/WorkflowStepHook.java
+++ b/flux-common/src/main/java/software/amazon/aws/clients/swf/flux/step/WorkflowStepHook.java
@@ -19,6 +19,49 @@ package software.amazon.aws.clients.swf.flux.step;
 /**
  * An interface marking a class to be a workflow step hook (i.e. something that is run before or after a step).
  * The class must define at least one method with the @StepHook annotation.
+ *
+ * Step hooks can be added using WorkflowGraphBuilder's addStepHook(), addHookForAllSteps(), or addWorkflowHook() methods.
+ *
+ * Step hooks are a mechanism to run arbitrary code before or after an actual workflow step is run.
+ * For example, a hook might be added before each step that cuts a ticket to an operator if the step has been
+ * running for more than 1 hour, or if it has retried too many times.
+ *
+ * Step hooks may also be attached to a workflow, rather than a step within a workflow; in this case, the
+ * hook code is executed either before the first workflow step, or after the last workflow step (regardless
+ * of which step was actually executed last).
+ *
+ * There are two types of hooks:
+ * - PRE hooks run before a workflow step's @StepApply method.
+ * - POST hooks run after the workflow step's @StepApply method, even if it threw an exception.
+ *
+ * When executing a workflow step, Flux first executes any PRE hooks, then executes the workflow step's
+ * @StepApply method, and finally executes any POST hooks.
+ *
+ * A step hook has access to the same set of input attributes as the workflow step it is attached to.
+ * PRE and POST hooks both have access to these attributes:
+ *
+ * - StepAttributes.ACTIVITY_NAME: String
+ *   The name of the step being hooked, in the format "{workflow-name}.{step-name}".
+ *   Only available to workflow step hooks, not workflow hooks.
+ *
+ * POST step hooks also have access to the step's output attributes as well as these two attributes
+ * if the step completed successfully:
+ *
+ * - StepAttributes.RESULT_CODE: (String)
+ *   The result code returned by the step (or determined by Flux, if the step didn't return a StepResult object).
+ *   This will be null if the step retried.
+ * - StepAttributes.ACTIVITY_COMPLETION_MESSAGE: (String)
+ *   The message included in the StepResult object returned by the @StepApply method
+ *   (or determined by Flux from a thrown Exception's message), if any.
+ *   This will be null if no message was provided.
+ *
+ * Flux does not enforce a limit on the number of hooks that can be added to a workflow or a workflow step.
+ * However, hooks are moderately difficult to debug, so it is recommended that only a minimum number of hooks be used.
+ * Step hooks are run in the activity thread, after heartbeating has started, so they won't normally cause a step to
+ * time out, but a workflow hook is executed by the decider thread, which does not heartbeat; if those hooks are expensive,
+ * the decider may time out.
+ *
+ * If the same hook is added to a step more than once, it will execute more than once.
  */
 public interface WorkflowStepHook {
 }

--- a/flux-common/src/main/java/software/amazon/aws/clients/swf/flux/wf/Workflow.java
+++ b/flux-common/src/main/java/software/amazon/aws/clients/swf/flux/wf/Workflow.java
@@ -57,6 +57,10 @@ public interface Workflow {
      * FluxCapacitor.executeWorkflow when it asks SWF to start the workflow execution.
      *
      * Defaults to 21 days.
+     *
+     * For best results, if a workflow can legitimately run for more than 21 days, the workflow should instead
+     * be split into multiple distinct workflows that each take less than 21 days. Only extend this duration
+     * if splitting the workflow in this manner is not possible.
      */
     default Duration maxStartToCloseDuration() {
         return WORKFLOW_EXECUTION_DEFAULT_START_TO_CLOSE_TIMEOUT;


### PR DESCRIPTION
Most of the documentation in our internal wiki fit neatly into javadocs on various classes.

Information about Flux's signal support was put into a separate `.md` file.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
