### PR TITLE
Version 2.0.1.

### DIFF
--- a/flux-common/pom.xml
+++ b/flux-common/pom.xml
@@ -5,12 +5,19 @@
     <parent>
         <groupId>software.amazon.aws.clients.swf.flux</groupId>
         <artifactId>flux-swf-client-pom</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
     </parent>
     <artifactId>flux-common</artifactId>
     <name>Flux SWF Client Common</name>
     <description>Flux is a client library that simplifies usage of Amazon Simple Workflow Service.</description>
     <url>https://github.com/awslabs/flux-swf-client</url>
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>https://aws.amazon.com/apache2.0</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
 
     <dependencies>
         <dependency>

--- a/flux-common/src/main/java/software/amazon/aws/clients/swf/flux/metrics/MetricRecorder.java
+++ b/flux-common/src/main/java/software/amazon/aws/clients/swf/flux/metrics/MetricRecorder.java
@@ -20,7 +20,9 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * A generic interface for emitting metrics to an arbitrary recording mechanism.
@@ -50,8 +52,9 @@ public abstract class MetricRecorder implements AutoCloseable {
     public final void close() {
         verifyNotClosed();
 
-        for (String openTimers : timers.keySet()) {
-            endDuration(openTimers);
+        Set<String> openTimers = new HashSet<>(timers.keySet());
+        for (String openTimer : openTimers) {
+            endDuration(openTimer);
         }
 
         addProperty(StandardMetricNames.OPERATION.toString(), operation);

--- a/flux-guice/pom.xml
+++ b/flux-guice/pom.xml
@@ -5,12 +5,19 @@
     <parent>
         <groupId>software.amazon.aws.clients.swf.flux</groupId>
         <artifactId>flux-swf-client-pom</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
     </parent>
     <artifactId>flux-guice</artifactId>
     <name>Flux SWF Client Guice Helper</name>
     <description>Flux is a client library that simplifies usage of Amazon Simple Workflow Service.</description>
     <url>https://github.com/awslabs/flux-swf-client</url>
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>https://aws.amazon.com/apache2.0</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
 
     <dependencies>
         <dependency>

--- a/flux-integration-tests/pom.xml
+++ b/flux-integration-tests/pom.xml
@@ -5,12 +5,19 @@
     <parent>
         <groupId>software.amazon.aws.clients.swf.flux</groupId>
         <artifactId>flux-swf-client-pom</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
     </parent>
     <artifactId>flux-integration-tests</artifactId>
     <name>Flux SWF Client integration tests</name>
     <description>Flux is a client library that simplifies usage of Amazon Simple Workflow Service.</description>
     <url>https://github.com/awslabs/flux-swf-client</url>
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>https://aws.amazon.com/apache2.0</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
 
     <dependencies>
 

--- a/flux-spring/pom.xml
+++ b/flux-spring/pom.xml
@@ -5,12 +5,19 @@
     <parent>
         <groupId>software.amazon.aws.clients.swf.flux</groupId>
         <artifactId>flux-swf-client-pom</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
     </parent>
     <artifactId>flux-spring</artifactId>
     <name>Flux SWF Client Spring Helper</name>
     <description>Flux is a client library that simplifies usage of Amazon Simple Workflow Service.</description>
     <url>https://github.com/awslabs/flux-swf-client</url>
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>https://aws.amazon.com/apache2.0</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
 
     <dependencies>
         <dependency>

--- a/flux-testutils/pom.xml
+++ b/flux-testutils/pom.xml
@@ -5,12 +5,19 @@
     <parent>
         <groupId>software.amazon.aws.clients.swf.flux</groupId>
         <artifactId>flux-swf-client-pom</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
     </parent>
     <artifactId>flux-testutils</artifactId>
     <name>Flux SWF Client Test Utils</name>
     <description>Flux is a client library that simplifies usage of Amazon Simple Workflow Service.</description>
     <url>https://github.com/awslabs/flux-swf-client</url>
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>https://aws.amazon.com/apache2.0</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
 
     <dependencies>
         <dependency>

--- a/flux/pom.xml
+++ b/flux/pom.xml
@@ -5,12 +5,19 @@
     <parent>
         <groupId>software.amazon.aws.clients.swf.flux</groupId>
         <artifactId>flux-swf-client-pom</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
     </parent>
     <artifactId>flux</artifactId>
     <name>Flux SWF Client</name>
     <description>Flux is a client library that simplifies usage of Amazon Simple Workflow Service.</description>
     <url>https://github.com/awslabs/flux-swf-client</url>
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>https://aws.amazon.com/apache2.0</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
 
     <dependencies>
         <dependency>

--- a/flux/src/main/java/software/amazon/aws/clients/swf/flux/FluxCapacitorImpl.java
+++ b/flux/src/main/java/software/amazon/aws/clients/swf/flux/FluxCapacitorImpl.java
@@ -97,9 +97,9 @@ public final class FluxCapacitorImpl implements FluxCapacitor {
     public static final double DEFAULT_EXPONENTIAL_BACKOFF_BASE = 1.25;
 
     private Map<String, ScheduledExecutorService> decisionTaskPollerThreadsPerTaskList;
-    private Map<String, ThreadPoolExecutor> deciderThreadsPerTaskList;
+    private Map<String, BlockOnSubmissionThreadPoolExecutor> deciderThreadsPerTaskList;
     private Map<String, ScheduledExecutorService> activityTaskPollerThreadsPerTaskList;
-    private Map<String, ThreadPoolExecutor> workerThreadsPerTaskList;
+    private Map<String, BlockOnSubmissionThreadPoolExecutor> workerThreadsPerTaskList;
     private Map<String, ScheduledExecutorService> periodicThreadsPerTaskList;
 
     private final MetricRecorderFactory metricsFactory;

--- a/flux/src/test/java/software/amazon/aws/clients/swf/flux/poller/BlockOnSubmissionThreadPoolExecutorTest.java
+++ b/flux/src/test/java/software/amazon/aws/clients/swf/flux/poller/BlockOnSubmissionThreadPoolExecutorTest.java
@@ -1,0 +1,95 @@
+/*
+ *   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package software.amazon.aws.clients.swf.flux.poller;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Supplier;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class BlockOnSubmissionThreadPoolExecutorTest {
+
+    private BlockOnSubmissionThreadPoolExecutor executor;
+
+    @Before
+    public void setup() {
+        executor = new BlockOnSubmissionThreadPoolExecutor(1);
+    }
+
+    @Test
+    public void executeWaitsToCallSupplierUntilThreadIsFree() throws InterruptedException, ExecutionException {
+        Duration delay = Duration.ofMillis(50);
+        CompletableFuture<Long> invokedAtNanoTime = new CompletableFuture<>();
+        Supplier<Runnable> supplier = () -> {
+            invokedAtNanoTime.complete(System.nanoTime());
+            return null;
+        };
+
+        long startNanoTime = System.nanoTime();
+        // Add a Runnable that sleeps for long enough to ensure that the thread pool thread is in use
+        // when we call the execute overload that takes a Supplier.
+        executor.execute(() -> {
+            try {
+                Thread.sleep(delay.toMillis());
+            } catch (InterruptedException e) {
+            }
+        });
+        Assert.assertTrue("The first call to execute should not block.", System.nanoTime() - startNanoTime < delay.toNanos());
+
+        executor.execute(supplier);
+        Assert.assertTrue("The supplier should not be executed until a thread pool thread is free.",
+                          // which means the supplier should only be invoked after the expected delay.
+                          invokedAtNanoTime.get() - startNanoTime > delay.toNanos());
+    }
+
+    @Test(timeout = 500)
+    public void semaphoreIsReleasedWhenSupplierReturnsNull() {
+        Supplier<Runnable> supplier = () -> null;
+
+        executor.execute(supplier);
+        // If the call above did not release the semaphore then the call below will block indefinitely
+        // (well, until the timeout configured on this junit test method).
+        executor.execute(() -> {});
+    }
+
+    @Test(timeout = 500)
+    public void executeRunnableReturnedBySupplier() throws InterruptedException, ExecutionException {
+        Duration delay = Duration.ofMillis(50);
+        CompletableFuture<Boolean> runnableInvoked = new CompletableFuture<>();
+        Supplier<Runnable> supplier = () -> () -> {
+            try {
+                Thread.sleep(delay.toMillis());
+            } catch (InterruptedException e) {
+            }
+            runnableInvoked.complete(true);
+        };
+
+        executor.execute(supplier);
+        // The call above should return before execution of the Runnable that was returned by the Supplier.
+        // The assertion below verifies that the Runnable is executed asynchronously without blocking the execute() call.
+        Assert.assertFalse("The Runnable should not have finished executing yet.", runnableInvoked.isDone());
+
+        // Note that the call to runnableInvoked.get() will block until the runnable completes the Future.
+        // So if the runnable does not get invoked the test will timeout.
+        Assert.assertTrue("The Runnable should have run.", runnableInvoked.get());
+    }
+
+}

--- a/flux/src/test/java/software/amazon/aws/clients/swf/flux/poller/DecisionTaskPollerTest.java
+++ b/flux/src/test/java/software/amazon/aws/clients/swf/flux/poller/DecisionTaskPollerTest.java
@@ -121,7 +121,7 @@ public class DecisionTaskPollerTest {
 
     private DecisionTaskPoller poller;
 
-    private ThreadPoolExecutor executor;
+    private BlockOnSubmissionThreadPoolExecutor executor;
 
     @Before
     public void setup() {

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>software.amazon.aws.clients.swf.flux</groupId>
     <artifactId>flux-swf-client-pom</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <packaging>pom</packaging>
     <name>Flux SWF Client POM</name>
     <description>Flux is a client library that simplifies usage of Amazon Simple Workflow Service.</description>


### PR DESCRIPTION
* Fix concurrent map modification in MetricRecorder.close().
* When heartbeating an activity, treat UnknownResourceException the same as if the activity were canceled.
* In ActivityTaskPoller and DecisionTaskPoller, don't poll for work until at least one worker thread is available.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
