### PR TITLE
Fix bug introduced by previous commit. 

### DIFF
--- a/flux/src/main/java/software/amazon/aws/clients/swf/flux/poller/BlockOnSubmissionThreadPoolExecutor.java
+++ b/flux/src/main/java/software/amazon/aws/clients/swf/flux/poller/BlockOnSubmissionThreadPoolExecutor.java
@@ -22,6 +22,9 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import software.amazon.aws.clients.swf.flux.util.ThreadUtils;
 
 /**
@@ -29,6 +32,8 @@ import software.amazon.aws.clients.swf.flux.util.ThreadUtils;
  * It does this using a semaphore, rather than trying to figure out how many active threads the pool reports.
  */
 public class BlockOnSubmissionThreadPoolExecutor extends ThreadPoolExecutor {
+
+    private final Logger log = LoggerFactory.getLogger(BlockOnSubmissionThreadPoolExecutor.class);
 
     private final Semaphore submissionSemaphore;
 
@@ -51,7 +56,7 @@ public class BlockOnSubmissionThreadPoolExecutor extends ThreadPoolExecutor {
      * Blocks until a thread is free, then executes the Supplier on the current thread and schedules the Runnable
      * to execute in the thread pool.
      */
-    public void execute(Supplier<Runnable> supplier) {
+    public void executeWhenCapacityAvailable(Supplier<Runnable> supplier) {
         submissionSemaphore.acquireUninterruptibly();
         Runnable runnable = null;
         try {

--- a/flux/src/test/java/software/amazon/aws/clients/swf/flux/poller/BlockOnSubmissionThreadPoolExecutorTest.java
+++ b/flux/src/test/java/software/amazon/aws/clients/swf/flux/poller/BlockOnSubmissionThreadPoolExecutorTest.java
@@ -54,7 +54,7 @@ public class BlockOnSubmissionThreadPoolExecutorTest {
         });
         Assert.assertTrue("The first call to execute should not block.", System.nanoTime() - startNanoTime < delay.toNanos());
 
-        executor.execute(supplier);
+        executor.executeWhenCapacityAvailable(supplier);
         Assert.assertTrue("The supplier should not be executed until a thread pool thread is free.",
                           // which means the supplier should only be invoked after the expected delay.
                           invokedAtNanoTime.get() - startNanoTime > delay.toNanos());
@@ -64,7 +64,7 @@ public class BlockOnSubmissionThreadPoolExecutorTest {
     public void semaphoreIsReleasedWhenSupplierReturnsNull() {
         Supplier<Runnable> supplier = () -> null;
 
-        executor.execute(supplier);
+        executor.executeWhenCapacityAvailable(supplier);
         // If the call above did not release the semaphore then the call below will block indefinitely
         // (well, until the timeout configured on this junit test method).
         executor.execute(() -> {});
@@ -82,7 +82,7 @@ public class BlockOnSubmissionThreadPoolExecutorTest {
             runnableInvoked.complete(true);
         };
 
-        executor.execute(supplier);
+        executor.executeWhenCapacityAvailable(supplier);
         // The call above should return before execution of the Runnable that was returned by the Supplier.
         // The assertion below verifies that the Runnable is executed asynchronously without blocking the execute() call.
         Assert.assertFalse("The Runnable should not have finished executing yet.", runnableInvoked.isDone());


### PR DESCRIPTION
The previous commit broke the unit tests.
* Fixed poller code so doesn't execute on the wrong thread pool.
* Renamed the Supplier overload of BlockOnSubmissionThreadPoolExecutor.execute() to prevent similar issues in the future.f BlockOnSubmissionThreadPoolExecutor.execute() to prevent similar issues in the future.

This time I actually ran the unit and integration tests before submitting the PR...

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
