### PR TITLE
Add support for Instant as an input and output attribute.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Flux supports `@Attribute` parameters of any of the following types:
 - `String`
 - `Long`
 - `Date`
+- `Instant`
 - `Boolean`
 - `Map<String, String>`
 - `software.amazon.aws.clients.swf.flux.metrics.MetricRecorder`

--- a/flux/src/main/java/software/amazon/aws/clients/swf/flux/poller/PartitionState.java
+++ b/flux/src/main/java/software/amazon/aws/clients/swf/flux/poller/PartitionState.java
@@ -16,8 +16,7 @@
 
 package software.amazon.aws.clients.swf.flux.poller;
 
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -35,8 +34,8 @@ import software.amazon.awssdk.services.swf.model.HistoryEvent;
 public final class PartitionState {
 
     private String activityId;
-    private OffsetDateTime attemptScheduledTime;
-    private OffsetDateTime attemptCompletedTime;
+    private Instant attemptScheduledTime;
+    private Instant attemptCompletedTime;
     private Map<String, String> attemptInput;
     private Map<String, String> attemptOutput;
     private StepResult.ResultAction attemptResult;
@@ -64,14 +63,14 @@ public final class PartitionState {
 
         PartitionState state = new PartitionState();
         state.activityId = scheduledEvent.activityTaskScheduledEventAttributes().activityId();
-        state.attemptScheduledTime = OffsetDateTime.ofInstant(scheduledEvent.eventTimestamp(), ZoneOffset.UTC);
+        state.attemptScheduledTime = scheduledEvent.eventTimestamp();
         state.attemptScheduledEventId = scheduledEvent.eventId();
         state.attemptInput = WorkflowState.getStepData(scheduledEvent);
 
         if (closedEvent != null) {
             state.attemptResult = WorkflowState.getStepResultAction(closedEvent);
             state.attemptOutput = WorkflowState.getStepData(closedEvent);
-            state.attemptCompletedTime = OffsetDateTime.ofInstant(closedEvent.eventTimestamp(), ZoneOffset.UTC);
+            state.attemptCompletedTime = closedEvent.eventTimestamp();
         } else {
             state.attemptResult = null;
             state.attemptOutput = Collections.emptyMap();
@@ -96,11 +95,11 @@ public final class PartitionState {
         return (count == null) ? 0L : count;
     }
 
-    public OffsetDateTime getAttemptScheduledTime() {
+    public Instant getAttemptScheduledTime() {
         return attemptScheduledTime;
     }
 
-    public OffsetDateTime getAttemptCompletedTime() {
+    public Instant getAttemptCompletedTime() {
         return attemptCompletedTime;
     }
 

--- a/flux/src/main/java/software/amazon/aws/clients/swf/flux/poller/WorkflowState.java
+++ b/flux/src/main/java/software/amazon/aws/clients/swf/flux/poller/WorkflowState.java
@@ -16,8 +16,7 @@
 
 package software.amazon.aws.clients.swf.flux.poller;
 
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -86,19 +85,19 @@ final class WorkflowState {
 
     private String workflowId;
     private String workflowRunId;
-    private OffsetDateTime workflowStartDate;
+    private Instant workflowStartDate;
     private Map<String, String> workflowInput;
     private String currentActivityName;
     private String currentStepResultCode;
-    private OffsetDateTime currentStepFirstScheduledTime;
-    private OffsetDateTime currentStepCompletionTime;
+    private Instant currentStepFirstScheduledTime;
+    private Instant currentStepCompletionTime;
     private String currentStepLastActivityCompletionMessage;
     private Long currentStepMaxRetryCount;
     private Map<String, Map<String, List<PartitionState>>> stepPartitions;
     private Map<String, TimerData> openTimers;
     private Map<String, Long> closedTimers;
     private Map<String, BaseSignalData> signalsByActivityId;
-    private OffsetDateTime workflowCancelRequestDate;
+    private Instant workflowCancelRequestDate;
     private boolean workflowExecutionClosed;
 
     public String getWorkflowId() {
@@ -109,7 +108,7 @@ final class WorkflowState {
         return workflowRunId;
     }
 
-    public OffsetDateTime getWorkflowStartDate() {
+    public Instant getWorkflowStartDate() {
         return workflowStartDate;
     }
 
@@ -125,11 +124,11 @@ final class WorkflowState {
         return currentStepResultCode;
     }
 
-    public OffsetDateTime getCurrentStepFirstScheduledTime() {
+    public Instant getCurrentStepFirstScheduledTime() {
         return currentStepFirstScheduledTime;
     }
 
-    public OffsetDateTime getCurrentStepCompletionTime() {
+    public Instant getCurrentStepCompletionTime() {
         return currentStepCompletionTime;
     }
 
@@ -164,7 +163,7 @@ final class WorkflowState {
         return workflowCancelRequestDate != null;
     }
 
-    public OffsetDateTime getWorkflowCancelRequestDate() {
+    public Instant getWorkflowCancelRequestDate() {
         return workflowCancelRequestDate;
     }
 
@@ -256,7 +255,7 @@ final class WorkflowState {
                 }
 
                 if (EventType.WORKFLOW_EXECUTION_STARTED.equals(event.eventType())) {
-                    ws.workflowStartDate = OffsetDateTime.ofInstant(event.eventTimestamp(), ZoneOffset.UTC);
+                    ws.workflowStartDate = event.eventTimestamp();
                     ws.workflowInput = getStepData(event);
                 } else if (EventType.ACTIVITY_TASK_SCHEDULED.equals(event.eventType())) {
                     String activityName = getActivityName(event);
@@ -300,8 +299,7 @@ final class WorkflowState {
                         // event of each type by only saving this signal if we don't already have one.
                         if (!ws.signalsByActivityId.containsKey(signalData.getActivityId())) {
                             signalData.setSignalEventId(event.eventId());
-                            signalData.setSignalEventTime(OffsetDateTime.ofInstant(event.eventTimestamp(),
-                                                                                   ZoneOffset.UTC));
+                            signalData.setSignalEventTime(event.eventTimestamp());
                             ws.signalsByActivityId.put(signalData.getActivityId(), signalData);
                         }
                     }
@@ -309,7 +307,7 @@ final class WorkflowState {
             } else if (WORKFLOW_CANCEL_REQUESTED_EVENTS.contains(event.eventType())) {
                 // if more than one cancellation request was sent, we'll just use the most recent one
                 if (ws.workflowCancelRequestDate == null) {
-                    ws.workflowCancelRequestDate = OffsetDateTime.ofInstant(event.eventTimestamp(), ZoneOffset.UTC);
+                    ws.workflowCancelRequestDate = event.eventTimestamp();
                 }
             } else if (WORKFLOW_END_EVENTS.contains(event.eventType())) {
                 ws.workflowExecutionClosed = true;

--- a/flux/src/main/java/software/amazon/aws/clients/swf/flux/poller/signals/BaseSignalData.java
+++ b/flux/src/main/java/software/amazon/aws/clients/swf/flux/poller/signals/BaseSignalData.java
@@ -16,7 +16,7 @@
 
 package software.amazon.aws.clients.swf.flux.poller.signals;
 
-import java.time.OffsetDateTime;
+import java.time.Instant;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -34,7 +34,7 @@ public abstract class BaseSignalData {
     private Long signalEventId;
 
     @JsonIgnore
-    private OffsetDateTime signalEventTime;
+    private Instant signalEventTime;
 
     private String activityId;
 
@@ -49,14 +49,14 @@ public abstract class BaseSignalData {
         this.signalEventId = signalEventId;
     }
 
-    public OffsetDateTime getSignalEventTime() {
+    public Instant getSignalEventTime() {
         return signalEventTime;
     }
 
     /**
      * This is only for internal use by the WorkflowState code, you don't need to set it in tests if you're just building events.
      */
-    public void setSignalEventTime(OffsetDateTime signalEventTime) {
+    public void setSignalEventTime(Instant signalEventTime) {
         this.signalEventTime = signalEventTime;
     }
 

--- a/flux/src/test/java/software/amazon/aws/clients/swf/flux/poller/DecisionTaskPollerTest.java
+++ b/flux/src/test/java/software/amazon/aws/clients/swf/flux/poller/DecisionTaskPollerTest.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.SSLException;
@@ -428,7 +427,7 @@ public class DecisionTaskPollerTest {
         input.put(StepAttributes.ACTIVITY_INITIAL_ATTEMPT_TIME, StepAttributes.encode(attemptTime));
         input.put(StepAttributes.WORKFLOW_ID, StepAttributes.encode(state.getWorkflowId()));
         input.put(StepAttributes.WORKFLOW_EXECUTION_ID, StepAttributes.encode(state.getWorkflowRunId()));
-        input.put(StepAttributes.WORKFLOW_START_TIME, StepAttributes.encode(Date.from(state.getWorkflowStartDate().toInstant())));
+        input.put(StepAttributes.WORKFLOW_START_TIME, StepAttributes.encode(state.getWorkflowStartDate()));
 
         String activityId = TaskNaming.createActivityId(workflow.getGraph().getFirstStep(), 0, null);
         ScheduleActivityTaskDecisionAttributes attrs
@@ -484,7 +483,7 @@ public class DecisionTaskPollerTest {
         expectedInput.put(StepAttributes.ACTIVITY_INITIAL_ATTEMPT_TIME, StepAttributes.encode(attemptTime));
         expectedInput.put(StepAttributes.WORKFLOW_ID, StepAttributes.encode(state.getWorkflowId()));
         expectedInput.put(StepAttributes.WORKFLOW_EXECUTION_ID, StepAttributes.encode(state.getWorkflowRunId()));
-        expectedInput.put(StepAttributes.WORKFLOW_START_TIME, StepAttributes.encode(Date.from(state.getWorkflowStartDate().toInstant())));
+        expectedInput.put(StepAttributes.WORKFLOW_START_TIME, StepAttributes.encode(state.getWorkflowStartDate()));
 
         String activityId = TaskNaming.createActivityId(stepTwo, 0, null);
         ScheduleActivityTaskDecisionAttributes attrs
@@ -554,7 +553,7 @@ public class DecisionTaskPollerTest {
         expectedInput.put(StepAttributes.ACTIVITY_INITIAL_ATTEMPT_TIME, StepAttributes.encode(attemptTime));
         expectedInput.put(StepAttributes.WORKFLOW_ID, StepAttributes.encode(state.getWorkflowId()));
         expectedInput.put(StepAttributes.WORKFLOW_EXECUTION_ID, StepAttributes.encode(state.getWorkflowRunId()));
-        expectedInput.put(StepAttributes.WORKFLOW_START_TIME, StepAttributes.encode(Date.from(state.getWorkflowStartDate().toInstant())));
+        expectedInput.put(StepAttributes.WORKFLOW_START_TIME, StepAttributes.encode(state.getWorkflowStartDate()));
 
         String activityId = TaskNaming.createActivityId(stepTwo, 0, null);
         ScheduleActivityTaskDecisionAttributes attrs
@@ -622,7 +621,7 @@ public class DecisionTaskPollerTest {
         expectedInput.put(StepAttributes.ACTIVITY_INITIAL_ATTEMPT_TIME, StepAttributes.encode(attemptTime));
         expectedInput.put(StepAttributes.WORKFLOW_ID, StepAttributes.encode(state.getWorkflowId()));
         expectedInput.put(StepAttributes.WORKFLOW_EXECUTION_ID, StepAttributes.encode(state.getWorkflowRunId()));
-        expectedInput.put(StepAttributes.WORKFLOW_START_TIME, StepAttributes.encode(Date.from(state.getWorkflowStartDate().toInstant())));
+        expectedInput.put(StepAttributes.WORKFLOW_START_TIME, StepAttributes.encode(state.getWorkflowStartDate()));
 
         String activityId = TaskNaming.createActivityId(stepTwo, 0, null);
         ScheduleActivityTaskDecisionAttributes attrs
@@ -702,7 +701,7 @@ public class DecisionTaskPollerTest {
 
             expectedInput.put(StepAttributes.WORKFLOW_ID, StepAttributes.encode(state.getWorkflowId()));
             expectedInput.put(StepAttributes.WORKFLOW_EXECUTION_ID, StepAttributes.encode(state.getWorkflowRunId()));
-            expectedInput.put(StepAttributes.WORKFLOW_START_TIME, StepAttributes.encode(Date.from(state.getWorkflowStartDate().toInstant())));
+            expectedInput.put(StepAttributes.WORKFLOW_START_TIME, StepAttributes.encode(state.getWorkflowStartDate()));
 
             // because this is the first attempt of the step and we don't control 'now' from the unit test,
             // the ACTIVITY_INITIAL_ATTEMPT_TIME will vary from test to test.
@@ -796,7 +795,7 @@ public class DecisionTaskPollerTest {
 
             expectedInput.put(StepAttributes.WORKFLOW_ID, StepAttributes.encode(state.getWorkflowId()));
             expectedInput.put(StepAttributes.WORKFLOW_EXECUTION_ID, StepAttributes.encode(state.getWorkflowRunId()));
-            expectedInput.put(StepAttributes.WORKFLOW_START_TIME, StepAttributes.encode(Date.from(state.getWorkflowStartDate().toInstant())));
+            expectedInput.put(StepAttributes.WORKFLOW_START_TIME, StepAttributes.encode(state.getWorkflowStartDate()));
 
             // the partition id generator should have added an extra attribute
             expectedInput.put(TestPartitionedStepUsesPartitionIdGeneratorResult.PARTITION_ID_GENERATOR_RESULT_ATTRIBUTE,
@@ -1008,7 +1007,7 @@ public class DecisionTaskPollerTest {
 
         expectedInput.put(StepAttributes.WORKFLOW_ID, StepAttributes.encode(state.getWorkflowId()));
         expectedInput.put(StepAttributes.WORKFLOW_EXECUTION_ID, StepAttributes.encode(state.getWorkflowRunId()));
-        expectedInput.put(StepAttributes.WORKFLOW_START_TIME, StepAttributes.encode(Date.from(state.getWorkflowStartDate().toInstant())));
+        expectedInput.put(StepAttributes.WORKFLOW_START_TIME, StepAttributes.encode(state.getWorkflowStartDate()));
 
         String activityId = TaskNaming.createActivityId(partitionedStep, 0, partitionId);
         ScheduleActivityTaskDecisionAttributes attrs
@@ -1144,7 +1143,7 @@ public class DecisionTaskPollerTest {
 
             expectedInput.put(StepAttributes.WORKFLOW_ID, StepAttributes.encode(state.getWorkflowId()));
             expectedInput.put(StepAttributes.WORKFLOW_EXECUTION_ID, StepAttributes.encode(state.getWorkflowRunId()));
-            expectedInput.put(StepAttributes.WORKFLOW_START_TIME, StepAttributes.encode(Date.from(state.getWorkflowStartDate().toInstant())));
+            expectedInput.put(StepAttributes.WORKFLOW_START_TIME, StepAttributes.encode(state.getWorkflowStartDate()));
             expectedInput.put(StepAttributes.ACTIVITY_INITIAL_ATTEMPT_TIME, StepAttributes.encode(Date.from(partitionFirstAttemptTimes.get(partitionId))));
 
             String activityId = TaskNaming.createActivityId(partitionedStep, 1, partitionId);
@@ -1213,7 +1212,7 @@ public class DecisionTaskPollerTest {
         expectedInput.putAll(output);
         expectedInput.put(StepAttributes.WORKFLOW_ID, StepAttributes.encode(state.getWorkflowId()));
         expectedInput.put(StepAttributes.WORKFLOW_EXECUTION_ID, StepAttributes.encode(state.getWorkflowRunId()));
-        expectedInput.put(StepAttributes.WORKFLOW_START_TIME, StepAttributes.encode(Date.from(state.getWorkflowStartDate().toInstant())));
+        expectedInput.put(StepAttributes.WORKFLOW_START_TIME, StepAttributes.encode(state.getWorkflowStartDate()));
 
         // because this is the first attempt of the step and we don't control 'now' from the unit test,
         // the ACTIVITY_INITIAL_ATTEMPT_TIME will vary from test to test.
@@ -1293,7 +1292,7 @@ public class DecisionTaskPollerTest {
         expectedInput.put(StepAttributes.ACTIVITY_INITIAL_ATTEMPT_TIME, StepAttributes.encode(attemptTime));
         expectedInput.put(StepAttributes.WORKFLOW_ID, StepAttributes.encode(state.getWorkflowId()));
         expectedInput.put(StepAttributes.WORKFLOW_EXECUTION_ID, StepAttributes.encode(state.getWorkflowRunId()));
-        expectedInput.put(StepAttributes.WORKFLOW_START_TIME, StepAttributes.encode(Date.from(state.getWorkflowStartDate().toInstant())));
+        expectedInput.put(StepAttributes.WORKFLOW_START_TIME, StepAttributes.encode(state.getWorkflowStartDate()));
 
         String activityId = TaskNaming.createActivityId(stepTwo, 0, null);
         ScheduleActivityTaskDecisionAttributes attrs
@@ -1408,12 +1407,12 @@ public class DecisionTaskPollerTest {
         input.put(StepAttributes.ACTIVITY_INITIAL_ATTEMPT_TIME, StepAttributes.encode(attemptTime));
         input.put(StepAttributes.WORKFLOW_ID, StepAttributes.encode(state.getWorkflowId()));
         input.put(StepAttributes.WORKFLOW_EXECUTION_ID, StepAttributes.encode(state.getWorkflowRunId()));
-        input.put(StepAttributes.WORKFLOW_START_TIME, StepAttributes.encode(Date.from(state.getWorkflowStartDate().toInstant())));
+        input.put(StepAttributes.WORKFLOW_START_TIME, StepAttributes.encode(state.getWorkflowStartDate()));
 
         // Start time of the workflow should match what was in the workflow state
-        Date workflowStartTime = StepAttributes.decode(Date.class, decisionInput.get(StepAttributes.WORKFLOW_START_TIME));
+        Instant workflowStartTime = StepAttributes.decode(Instant.class, decisionInput.get(StepAttributes.WORKFLOW_START_TIME));
         Assert.assertNotNull(workflowStartTime);
-        Assert.assertEquals(state.getWorkflowStartDate().toInstant(), workflowStartTime.toInstant());
+        Assert.assertEquals(state.getWorkflowStartDate(), workflowStartTime);
         input.put(StepAttributes.WORKFLOW_START_TIME, StepAttributes.encode(workflowStartTime));
 
         String activityId = TaskNaming.createActivityId(workflow.getGraph().getFirstStep(), 0, null);
@@ -1455,7 +1454,7 @@ public class DecisionTaskPollerTest {
         input.put(StepAttributes.RETRY_ATTEMPT, Integer.toString(1));
         input.put(StepAttributes.WORKFLOW_ID, StepAttributes.encode(state.getWorkflowId()));
         input.put(StepAttributes.WORKFLOW_EXECUTION_ID, StepAttributes.encode(state.getWorkflowRunId()));
-        input.put(StepAttributes.WORKFLOW_START_TIME, StepAttributes.encode(Date.from(state.getWorkflowStartDate().toInstant())));
+        input.put(StepAttributes.WORKFLOW_START_TIME, StepAttributes.encode(state.getWorkflowStartDate()));
 
         String activityId = TaskNaming.createActivityId(currentStep, 1, null);
         ScheduleActivityTaskDecisionAttributes attrs
@@ -1804,7 +1803,7 @@ public class DecisionTaskPollerTest {
 
         input.put(StepAttributes.WORKFLOW_ID, StepAttributes.encode(state.getWorkflowId()));
         input.put(StepAttributes.WORKFLOW_EXECUTION_ID, StepAttributes.encode(state.getWorkflowRunId()));
-        input.put(StepAttributes.WORKFLOW_START_TIME, StepAttributes.encode(Date.from(state.getWorkflowStartDate().toInstant())));
+        input.put(StepAttributes.WORKFLOW_START_TIME, StepAttributes.encode(state.getWorkflowStartDate()));
         input.put(StepAttributes.ACTIVITY_INITIAL_ATTEMPT_TIME, StepAttributes.encode(Date.from(startEvent1.eventTimestamp())));
         input.put(StepAttributes.RETRY_ATTEMPT, Integer.toString(1));
 
@@ -1933,7 +1932,7 @@ public class DecisionTaskPollerTest {
         expectedInput.putAll(output);
         expectedInput.put(StepAttributes.WORKFLOW_ID, StepAttributes.encode(state.getWorkflowId()));
         expectedInput.put(StepAttributes.WORKFLOW_EXECUTION_ID, StepAttributes.encode(state.getWorkflowRunId()));
-        expectedInput.put(StepAttributes.WORKFLOW_START_TIME, StepAttributes.encode(Date.from(state.getWorkflowStartDate().toInstant())));
+        expectedInput.put(StepAttributes.WORKFLOW_START_TIME, StepAttributes.encode(state.getWorkflowStartDate()));
 
         // because this is the first attempt of the step and we don't control 'now' from the unit test,
         // the ACTIVITY_INITIAL_ATTEMPT_TIME will vary from test to test.
@@ -2020,7 +2019,7 @@ public class DecisionTaskPollerTest {
         expectedInput.putAll(output);
         expectedInput.put(StepAttributes.WORKFLOW_ID, StepAttributes.encode(state.getWorkflowId()));
         expectedInput.put(StepAttributes.WORKFLOW_EXECUTION_ID, StepAttributes.encode(state.getWorkflowRunId()));
-        expectedInput.put(StepAttributes.WORKFLOW_START_TIME, StepAttributes.encode(Date.from(state.getWorkflowStartDate().toInstant())));
+        expectedInput.put(StepAttributes.WORKFLOW_START_TIME, StepAttributes.encode(state.getWorkflowStartDate()));
 
         // because this is the first attempt of the step and we don't control 'now' from the unit test,
         // the ACTIVITY_INITIAL_ATTEMPT_TIME will vary from test to test.
@@ -2264,7 +2263,7 @@ public class DecisionTaskPollerTest {
         String stepOneActivityName = TaskNaming.activityName(workflowName, stepOne);
         Assert.assertEquals(close1Event.eventTimestamp().toEpochMilli() - start1Event.eventTimestamp().toEpochMilli(),
                             deciderMetrics.getDurations().get(DecisionTaskPoller.formatStepCompletionTimeMetricName(stepOneActivityName)).toMillis());
-        Assert.assertEquals(cancelRequestEvent.eventTimestamp().toEpochMilli() - Date.from(state.getWorkflowStartDate().toInstant()).getTime(),
+        Assert.assertEquals(cancelRequestEvent.eventTimestamp().toEpochMilli() - state.getWorkflowStartDate().toEpochMilli(),
                             deciderMetrics.getDurations().get(DecisionTaskPoller.formatWorkflowCompletionTimeMetricName(workflowName)).toMillis());
         Assert.assertEquals(state.getWorkflowId(), deciderMetrics.getProperties().get(DecisionTaskPoller.WORKFLOW_ID_METRIC_NAME));
         Assert.assertEquals(state.getWorkflowRunId(), deciderMetrics.getProperties().get(DecisionTaskPoller.WORKFLOW_RUN_ID_METRIC_NAME));
@@ -2307,7 +2306,7 @@ public class DecisionTaskPollerTest {
         String stepOneActivityName = TaskNaming.activityName(workflowName, stepOne);
         Assert.assertEquals(cancelRequestEvent.eventTimestamp().toEpochMilli() - start1Event.eventTimestamp().toEpochMilli(),
                             deciderMetrics.getDurations().get(DecisionTaskPoller.formatStepCompletionTimeMetricName(stepOneActivityName)).toMillis());
-        Assert.assertEquals(cancelRequestEvent.eventTimestamp().toEpochMilli() - Date.from(state.getWorkflowStartDate().toInstant()).getTime(),
+        Assert.assertEquals(cancelRequestEvent.eventTimestamp().toEpochMilli() - state.getWorkflowStartDate().toEpochMilli(),
                             deciderMetrics.getDurations().get(DecisionTaskPoller.formatWorkflowCompletionTimeMetricName(workflowName)).toMillis());
         Assert.assertEquals(state.getWorkflowId(), deciderMetrics.getProperties().get(DecisionTaskPoller.WORKFLOW_ID_METRIC_NAME));
         Assert.assertEquals(state.getWorkflowRunId(), deciderMetrics.getProperties().get(DecisionTaskPoller.WORKFLOW_RUN_ID_METRIC_NAME));
@@ -2355,7 +2354,7 @@ public class DecisionTaskPollerTest {
         String stepOneActivityName = TaskNaming.activityName(workflowName, stepOne);
         Assert.assertEquals(cancelRequestEvent.eventTimestamp().toEpochMilli() - start1Event.eventTimestamp().toEpochMilli(),
                             deciderMetrics.getDurations().get(DecisionTaskPoller.formatStepCompletionTimeMetricName(stepOneActivityName)).toMillis());
-        Assert.assertEquals(cancelRequestEvent.eventTimestamp().toEpochMilli() - Date.from(state.getWorkflowStartDate().toInstant()).getTime(),
+        Assert.assertEquals(cancelRequestEvent.eventTimestamp().toEpochMilli() - state.getWorkflowStartDate().toEpochMilli(),
                             deciderMetrics.getDurations().get(DecisionTaskPoller.formatWorkflowCompletionTimeMetricName(workflowName)).toMillis());
         Assert.assertEquals(state.getWorkflowId(), deciderMetrics.getProperties().get(DecisionTaskPoller.WORKFLOW_ID_METRIC_NAME));
         Assert.assertEquals(state.getWorkflowRunId(), deciderMetrics.getProperties().get(DecisionTaskPoller.WORKFLOW_RUN_ID_METRIC_NAME));
@@ -2405,7 +2404,7 @@ public class DecisionTaskPollerTest {
         String activityName = TaskNaming.activityName(workflowName, currentStep);
         Assert.assertEquals(cancelRequestEvent.eventTimestamp().toEpochMilli() - start1Event.eventTimestamp().toEpochMilli(),
                             deciderMetrics.getDurations().get(DecisionTaskPoller.formatStepCompletionTimeMetricName(activityName)).toMillis());
-        Assert.assertEquals(cancelRequestEvent.eventTimestamp().toEpochMilli() - Date.from(state.getWorkflowStartDate().toInstant()).getTime(),
+        Assert.assertEquals(cancelRequestEvent.eventTimestamp().toEpochMilli() - state.getWorkflowStartDate().toEpochMilli(),
                             deciderMetrics.getDurations().get(DecisionTaskPoller.formatWorkflowCompletionTimeMetricName(workflowName)).toMillis());
         Assert.assertEquals(state.getWorkflowId(), deciderMetrics.getProperties().get(DecisionTaskPoller.WORKFLOW_ID_METRIC_NAME));
         Assert.assertEquals(state.getWorkflowRunId(), deciderMetrics.getProperties().get(DecisionTaskPoller.WORKFLOW_RUN_ID_METRIC_NAME));
@@ -2440,7 +2439,7 @@ public class DecisionTaskPollerTest {
         Assert.assertEquals(attrs, decision.completeWorkflowExecutionDecisionAttributes());
 
         String stepTwoActivityName = TaskNaming.activityName(workflowName, stepTwo);
-        Assert.assertEquals(close2Event.eventTimestamp().toEpochMilli() - Date.from(state.getWorkflowStartDate().toInstant()).getTime(),
+        Assert.assertEquals(close2Event.eventTimestamp().toEpochMilli() - state.getWorkflowStartDate().toEpochMilli(),
                             deciderMetrics.getDurations().get(DecisionTaskPoller.formatWorkflowCompletionTimeMetricName(workflowName)).toMillis());
         Assert.assertEquals(close2Event.eventTimestamp().toEpochMilli() - start2Event.eventTimestamp().toEpochMilli(),
                             deciderMetrics.getDurations().get(DecisionTaskPoller.formatStepCompletionTimeMetricName(stepTwoActivityName)).toMillis());
@@ -2480,7 +2479,7 @@ public class DecisionTaskPollerTest {
         Assert.assertTrue(decision.failWorkflowExecutionDecisionAttributes().reason().startsWith(activityName + " failed after"));
         Assert.assertNotNull("FailWorkflowExecutionDecision detail should not be null!", decision.failWorkflowExecutionDecisionAttributes().details());
 
-        Assert.assertEquals(close1Event.eventTimestamp().toEpochMilli() - Date.from(state.getWorkflowStartDate().toInstant()).getTime(),
+        Assert.assertEquals(close1Event.eventTimestamp().toEpochMilli() - state.getWorkflowStartDate().toEpochMilli(),
                             deciderMetrics.getDurations().get(DecisionTaskPoller.formatWorkflowCompletionTimeMetricName(workflowWithFailureTransitionName)).toMillis());
         Assert.assertEquals(close1Event.eventTimestamp().toEpochMilli() - start1Event.eventTimestamp().toEpochMilli(),
                             deciderMetrics.getDurations().get(DecisionTaskPoller.formatStepCompletionTimeMetricName(activityName)).toMillis());
@@ -2520,7 +2519,7 @@ public class DecisionTaskPollerTest {
 
         // we want to see a workflow execution time metric emitted when the periodic workflow ends, before the delayed exit
         String stepTwoActivityName = TaskNaming.activityName(periodicWorkflowName, stepTwo);
-        Assert.assertEquals(close2Event.eventTimestamp().toEpochMilli() - Date.from(state.getWorkflowStartDate().toInstant()).getTime(),
+        Assert.assertEquals(close2Event.eventTimestamp().toEpochMilli() - state.getWorkflowStartDate().toEpochMilli(),
                             deciderMetrics.getDurations().get(DecisionTaskPoller.formatWorkflowCompletionTimeMetricName(periodicWorkflowName)).toMillis());
         Assert.assertEquals(close2Event.eventTimestamp().toEpochMilli() - start2Event.eventTimestamp().toEpochMilli(),
                             deciderMetrics.getDurations().get(DecisionTaskPoller.formatStepCompletionTimeMetricName(stepTwoActivityName)).toMillis());
@@ -2532,7 +2531,7 @@ public class DecisionTaskPollerTest {
 
         // the timer should be set to end such that the workflow will be run once per period;
         // so the actual delay scheduled should be within a few seconds of the remaining time.
-        long timeSinceWorkflowStart = now.toEpochMilli() - Date.from(state.getWorkflowStartDate().toInstant()).getTime();
+        long timeSinceWorkflowStart = now.toEpochMilli() - state.getWorkflowStartDate().toEpochMilli();
         long expectedDelay = p.intervalUnits().toSeconds(p.runInterval()) - (timeSinceWorkflowStart/1000);
         long allowedDelta = 2;
         // start-to-fire timeout is in seconds
@@ -2573,7 +2572,7 @@ public class DecisionTaskPollerTest {
 
         // we want to see a workflow execution time metric emitted when the periodic workflow ends, before the delayed exit
         String stepTwoActivityName = TaskNaming.activityName(periodicWorkflowName, stepTwo);
-        Assert.assertEquals(close2Event.eventTimestamp().toEpochMilli() - Date.from(state.getWorkflowStartDate().toInstant()).getTime(),
+        Assert.assertEquals(close2Event.eventTimestamp().toEpochMilli() - state.getWorkflowStartDate().toEpochMilli(),
                             deciderMetrics.getDurations().get(DecisionTaskPoller.formatWorkflowCompletionTimeMetricName(periodicWorkflowName)).toMillis());
         Assert.assertEquals(close2Event.eventTimestamp().toEpochMilli() - start2Event.eventTimestamp().toEpochMilli(),
                             deciderMetrics.getDurations().get(DecisionTaskPoller.formatStepCompletionTimeMetricName(stepTwoActivityName)).toMillis());

--- a/flux/src/test/java/software/amazon/aws/clients/swf/flux/poller/WorkflowStateTest.java
+++ b/flux/src/test/java/software/amazon/aws/clients/swf/flux/poller/WorkflowStateTest.java
@@ -18,12 +18,9 @@ package software.amazon.aws.clients.swf.flux.poller;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -102,7 +99,7 @@ public class WorkflowStateTest {
         WorkflowHistoryBuilder history = WorkflowHistoryBuilder.startWorkflow(workflow, now, input);
         WorkflowState ws = history.buildCurrentState();
 
-        Assert.assertEquals(OffsetDateTime.ofInstant(now, ZoneOffset.UTC), ws.getWorkflowStartDate());
+        Assert.assertEquals(now, ws.getWorkflowStartDate());
         Assert.assertEquals(input, ws.getWorkflowInput());
         Assert.assertTrue(ws.getOpenTimers().isEmpty());
         Assert.assertTrue(ws.getClosedTimers().isEmpty());
@@ -138,7 +135,7 @@ public class WorkflowStateTest {
         HistoryEvent endEvent = history.recordActivityResult(StepResult.success().withAttributes(output));
         WorkflowState ws = history.buildCurrentState();
 
-        Assert.assertEquals(OffsetDateTime.ofInstant(now, ZoneOffset.UTC), ws.getWorkflowStartDate());
+        Assert.assertEquals(now, ws.getWorkflowStartDate());
         Assert.assertEquals(input, ws.getWorkflowInput());
         Assert.assertTrue(ws.getOpenTimers().isEmpty());
         Assert.assertTrue(ws.getClosedTimers().isEmpty());
@@ -148,8 +145,8 @@ public class WorkflowStateTest {
         Assert.assertFalse(ws.isWorkflowExecutionClosed());
 
         Assert.assertEquals(firstActivityName, ws.getCurrentActivityName());
-        Assert.assertEquals(OffsetDateTime.ofInstant(startEvent.eventTimestamp(), ZoneOffset.UTC), ws.getCurrentStepFirstScheduledTime());
-        Assert.assertEquals(OffsetDateTime.ofInstant(endEvent.eventTimestamp(), ZoneOffset.UTC), ws.getCurrentStepCompletionTime());
+        Assert.assertEquals(startEvent.eventTimestamp(), ws.getCurrentStepFirstScheduledTime());
+        Assert.assertEquals(endEvent.eventTimestamp(), ws.getCurrentStepCompletionTime());
         Assert.assertEquals(0L, (long)ws.getCurrentStepMaxRetryCount());
         Assert.assertEquals(StepResult.SUCCEED_RESULT_CODE, ws.getCurrentStepResultCode());
 
@@ -182,7 +179,7 @@ public class WorkflowStateTest {
         HistoryEvent endEvent = history.recordActivityResult(StepResult.failure().withAttributes(output));
         WorkflowState ws = history.buildCurrentState();
 
-        Assert.assertEquals(OffsetDateTime.ofInstant(now, ZoneOffset.UTC), ws.getWorkflowStartDate());
+        Assert.assertEquals(now, ws.getWorkflowStartDate());
         Assert.assertEquals(input, ws.getWorkflowInput());
         Assert.assertTrue(ws.getOpenTimers().isEmpty());
         Assert.assertTrue(ws.getClosedTimers().isEmpty());
@@ -192,8 +189,8 @@ public class WorkflowStateTest {
         Assert.assertFalse(ws.isWorkflowExecutionClosed());
 
         Assert.assertEquals(firstActivityName, ws.getCurrentActivityName());
-        Assert.assertEquals(OffsetDateTime.ofInstant(startEvent.eventTimestamp(), ZoneOffset.UTC), ws.getCurrentStepFirstScheduledTime());
-        Assert.assertEquals(OffsetDateTime.ofInstant(endEvent.eventTimestamp(), ZoneOffset.UTC), ws.getCurrentStepCompletionTime());
+        Assert.assertEquals(startEvent.eventTimestamp(), ws.getCurrentStepFirstScheduledTime());
+        Assert.assertEquals(endEvent.eventTimestamp(), ws.getCurrentStepCompletionTime());
         Assert.assertEquals(0L, (long)ws.getCurrentStepMaxRetryCount());
         Assert.assertEquals(StepResult.FAIL_RESULT_CODE, ws.getCurrentStepResultCode());
 
@@ -227,7 +224,7 @@ public class WorkflowStateTest {
         HistoryEvent endEvent = history.recordActivityResult(StepResult.success(TestBranchingWorkflow.CUSTOM_RESULT, completionMessage).withAttributes(output));
         WorkflowState ws = history.buildCurrentState();
 
-        Assert.assertEquals(OffsetDateTime.ofInstant(now, ZoneOffset.UTC), ws.getWorkflowStartDate());
+        Assert.assertEquals(now, ws.getWorkflowStartDate());
         Assert.assertEquals(input, ws.getWorkflowInput());
         Assert.assertTrue(ws.getOpenTimers().isEmpty());
         Assert.assertTrue(ws.getClosedTimers().isEmpty());
@@ -237,8 +234,8 @@ public class WorkflowStateTest {
         Assert.assertFalse(ws.isWorkflowExecutionClosed());
 
         Assert.assertEquals(firstActivityName, ws.getCurrentActivityName());
-        Assert.assertEquals(OffsetDateTime.ofInstant(startEvent.eventTimestamp(), ZoneOffset.UTC), ws.getCurrentStepFirstScheduledTime());
-        Assert.assertEquals(OffsetDateTime.ofInstant(endEvent.eventTimestamp(), ZoneOffset.UTC), ws.getCurrentStepCompletionTime());
+        Assert.assertEquals(startEvent.eventTimestamp(), ws.getCurrentStepFirstScheduledTime());
+        Assert.assertEquals(endEvent.eventTimestamp(), ws.getCurrentStepCompletionTime());
         Assert.assertEquals(0L, (long)ws.getCurrentStepMaxRetryCount());
         Assert.assertEquals(TestBranchingWorkflow.CUSTOM_RESULT, ws.getCurrentStepResultCode());
 
@@ -276,7 +273,7 @@ public class WorkflowStateTest {
 
         WorkflowState ws = history.buildCurrentState();
 
-        Assert.assertEquals(OffsetDateTime.ofInstant(now, ZoneOffset.UTC), ws.getWorkflowStartDate());
+        Assert.assertEquals(now, ws.getWorkflowStartDate());
         Assert.assertEquals(input, ws.getWorkflowInput());
         Assert.assertTrue(ws.getOpenTimers().isEmpty());
         Assert.assertTrue(ws.getClosedTimers().isEmpty());
@@ -287,7 +284,7 @@ public class WorkflowStateTest {
 
         Assert.assertEquals(partitionedStepName, ws.getCurrentActivityName());
         Assert.assertNull(ws.getCurrentStepResultCode());
-        Assert.assertEquals(OffsetDateTime.ofInstant(startP1Event.eventTimestamp(), ZoneOffset.UTC), ws.getCurrentStepFirstScheduledTime());
+        Assert.assertEquals(startP1Event.eventTimestamp(), ws.getCurrentStepFirstScheduledTime());
         Assert.assertNull(ws.getCurrentStepCompletionTime());
         Assert.assertEquals(0L, (long)ws.getCurrentStepMaxRetryCount());
 
@@ -328,7 +325,7 @@ public class WorkflowStateTest {
 
         WorkflowState ws = history.buildCurrentState();
 
-        Assert.assertEquals(OffsetDateTime.ofInstant(now, ZoneOffset.UTC), ws.getWorkflowStartDate());
+        Assert.assertEquals(now, ws.getWorkflowStartDate());
         Assert.assertEquals(input, ws.getWorkflowInput());
         Assert.assertTrue(ws.getOpenTimers().isEmpty());
         Assert.assertTrue(ws.getClosedTimers().isEmpty());
@@ -339,7 +336,7 @@ public class WorkflowStateTest {
 
         Assert.assertEquals(partitionedStepName, ws.getCurrentActivityName());
         Assert.assertNull(ws.getCurrentStepResultCode());
-        Assert.assertEquals(OffsetDateTime.ofInstant(startP1Event.eventTimestamp(), ZoneOffset.UTC), ws.getCurrentStepFirstScheduledTime());
+        Assert.assertEquals(startP1Event.eventTimestamp(), ws.getCurrentStepFirstScheduledTime());
         Assert.assertNull(ws.getCurrentStepCompletionTime());
         Assert.assertEquals(0L, (long)ws.getCurrentStepMaxRetryCount());
 
@@ -380,7 +377,7 @@ public class WorkflowStateTest {
 
         WorkflowState ws = history.buildCurrentState();
 
-        Assert.assertEquals(OffsetDateTime.ofInstant(now, ZoneOffset.UTC), ws.getWorkflowStartDate());
+        Assert.assertEquals(now, ws.getWorkflowStartDate());
         Assert.assertEquals(input, ws.getWorkflowInput());
         Assert.assertTrue(ws.getOpenTimers().isEmpty());
         Assert.assertTrue(ws.getClosedTimers().isEmpty());
@@ -391,7 +388,7 @@ public class WorkflowStateTest {
 
         Assert.assertEquals(partitionedStepName, ws.getCurrentActivityName());
         Assert.assertNull(ws.getCurrentStepResultCode());
-        Assert.assertEquals(OffsetDateTime.ofInstant(startP1Event.eventTimestamp(), ZoneOffset.UTC), ws.getCurrentStepFirstScheduledTime());
+        Assert.assertEquals(startP1Event.eventTimestamp(), ws.getCurrentStepFirstScheduledTime());
         Assert.assertNull(ws.getCurrentStepCompletionTime());
         Assert.assertEquals(0L, (long)ws.getCurrentStepMaxRetryCount());
 
@@ -431,7 +428,7 @@ public class WorkflowStateTest {
 
         WorkflowState ws = history.buildCurrentState();
 
-        Assert.assertEquals(OffsetDateTime.ofInstant(now, ZoneOffset.UTC), ws.getWorkflowStartDate());
+        Assert.assertEquals(now, ws.getWorkflowStartDate());
         Assert.assertEquals(input, ws.getWorkflowInput());
         Assert.assertTrue(ws.getOpenTimers().isEmpty());
         Assert.assertTrue(ws.getClosedTimers().isEmpty());
@@ -442,7 +439,7 @@ public class WorkflowStateTest {
 
         Assert.assertEquals(partitionedStepName, ws.getCurrentActivityName());
         Assert.assertNull(ws.getCurrentStepResultCode());
-        Assert.assertEquals(OffsetDateTime.ofInstant(startP1Event.eventTimestamp(), ZoneOffset.UTC), ws.getCurrentStepFirstScheduledTime());
+        Assert.assertEquals(startP1Event.eventTimestamp(), ws.getCurrentStepFirstScheduledTime());
         Assert.assertNull(ws.getCurrentStepCompletionTime());
         Assert.assertEquals(0L, (long)ws.getCurrentStepMaxRetryCount());
 
@@ -485,7 +482,7 @@ public class WorkflowStateTest {
 
         WorkflowState ws = history.buildCurrentState();
 
-        Assert.assertEquals(OffsetDateTime.ofInstant(now, ZoneOffset.UTC), ws.getWorkflowStartDate());
+        Assert.assertEquals(now, ws.getWorkflowStartDate());
         Assert.assertEquals(input, ws.getWorkflowInput());
         Assert.assertTrue(ws.getOpenTimers().isEmpty());
         Assert.assertTrue(ws.getClosedTimers().isEmpty());
@@ -496,7 +493,7 @@ public class WorkflowStateTest {
 
         Assert.assertEquals(partitionedStepName, ws.getCurrentActivityName());
         Assert.assertNull(ws.getCurrentStepResultCode());
-        Assert.assertEquals(OffsetDateTime.ofInstant(startP2Event.eventTimestamp(), ZoneOffset.UTC), ws.getCurrentStepFirstScheduledTime());
+        Assert.assertEquals(startP2Event.eventTimestamp(), ws.getCurrentStepFirstScheduledTime());
         Assert.assertNull(ws.getCurrentStepCompletionTime());
         Assert.assertEquals(0L, (long)ws.getCurrentStepMaxRetryCount());
 
@@ -538,7 +535,7 @@ public class WorkflowStateTest {
 
         WorkflowState ws = history.buildCurrentState();
 
-        Assert.assertEquals(OffsetDateTime.ofInstant(now, ZoneOffset.UTC), ws.getWorkflowStartDate());
+        Assert.assertEquals(now, ws.getWorkflowStartDate());
         Assert.assertEquals(input, ws.getWorkflowInput());
         Assert.assertTrue(ws.getOpenTimers().isEmpty());
         Assert.assertTrue(ws.getClosedTimers().isEmpty());
@@ -548,8 +545,8 @@ public class WorkflowStateTest {
         Assert.assertFalse(ws.isWorkflowExecutionClosed());
 
         Assert.assertEquals(firstStepName, ws.getCurrentActivityName());
-        Assert.assertEquals(OffsetDateTime.ofInstant(step1Start.eventTimestamp(), ZoneOffset.UTC), ws.getCurrentStepFirstScheduledTime());
-        Assert.assertEquals(OffsetDateTime.ofInstant(step1End.eventTimestamp(), ZoneOffset.UTC), ws.getCurrentStepCompletionTime());
+        Assert.assertEquals(step1Start.eventTimestamp(), ws.getCurrentStepFirstScheduledTime());
+        Assert.assertEquals(step1End.eventTimestamp(), ws.getCurrentStepCompletionTime());
         Assert.assertEquals(0L, (long)ws.getCurrentStepMaxRetryCount());
         Assert.assertEquals(StepResult.SUCCEED_RESULT_CODE, ws.getCurrentStepResultCode());
 
@@ -589,7 +586,7 @@ public class WorkflowStateTest {
 
         WorkflowState ws = history.buildCurrentState();
 
-        Assert.assertEquals(OffsetDateTime.ofInstant(now, ZoneOffset.UTC), ws.getWorkflowStartDate());
+        Assert.assertEquals(now, ws.getWorkflowStartDate());
         Assert.assertEquals(input, ws.getWorkflowInput());
         Assert.assertTrue(ws.getOpenTimers().isEmpty());
         Assert.assertTrue(ws.getClosedTimers().isEmpty());
@@ -600,8 +597,8 @@ public class WorkflowStateTest {
 
         Assert.assertEquals(partitionedStepName, ws.getCurrentActivityName());
         Assert.assertEquals(StepResult.SUCCEED_RESULT_CODE, ws.getCurrentStepResultCode());
-        Assert.assertEquals(OffsetDateTime.ofInstant(startP1Event.eventTimestamp(), ZoneOffset.UTC), ws.getCurrentStepFirstScheduledTime());
-        Assert.assertEquals(OffsetDateTime.ofInstant(closeP2Event.eventTimestamp(), ZoneOffset.UTC), ws.getCurrentStepCompletionTime());
+        Assert.assertEquals(startP1Event.eventTimestamp(), ws.getCurrentStepFirstScheduledTime());
+        Assert.assertEquals(closeP2Event.eventTimestamp(), ws.getCurrentStepCompletionTime());
         Assert.assertEquals(0L, (long)ws.getCurrentStepMaxRetryCount());
 
         Assert.assertNotNull(ws.getStepPartitions());
@@ -640,7 +637,7 @@ public class WorkflowStateTest {
 
         WorkflowState ws = history.buildCurrentState();
 
-        Assert.assertEquals(OffsetDateTime.ofInstant(now, ZoneOffset.UTC), ws.getWorkflowStartDate());
+        Assert.assertEquals(now, ws.getWorkflowStartDate());
         Assert.assertEquals(input, ws.getWorkflowInput());
         Assert.assertTrue(ws.getOpenTimers().isEmpty());
         Assert.assertTrue(ws.getClosedTimers().isEmpty());
@@ -651,8 +648,8 @@ public class WorkflowStateTest {
 
         Assert.assertEquals(partitionedStepName, ws.getCurrentActivityName());
         Assert.assertEquals(StepResult.FAIL_RESULT_CODE, ws.getCurrentStepResultCode());
-        Assert.assertEquals(OffsetDateTime.ofInstant(startP1Event.eventTimestamp(), ZoneOffset.UTC), ws.getCurrentStepFirstScheduledTime());
-        Assert.assertEquals(OffsetDateTime.ofInstant(closeP2Event.eventTimestamp(), ZoneOffset.UTC), ws.getCurrentStepCompletionTime());
+        Assert.assertEquals(startP1Event.eventTimestamp(), ws.getCurrentStepFirstScheduledTime());
+        Assert.assertEquals(closeP2Event.eventTimestamp(), ws.getCurrentStepCompletionTime());
         Assert.assertEquals(0L, (long)ws.getCurrentStepMaxRetryCount());
 
         Assert.assertNotNull(ws.getStepPartitions());
@@ -710,7 +707,7 @@ public class WorkflowStateTest {
 
         WorkflowState ws = history.buildCurrentState();
 
-        Assert.assertEquals(OffsetDateTime.ofInstant(now, ZoneOffset.UTC), ws.getWorkflowStartDate());
+        Assert.assertEquals(now, ws.getWorkflowStartDate());
         Assert.assertEquals(input, ws.getWorkflowInput());
         Assert.assertTrue(ws.getOpenTimers().isEmpty());
         Assert.assertEquals(4, ws.getClosedTimers().size()); // two retries each for two partitions
@@ -725,8 +722,8 @@ public class WorkflowStateTest {
 
         Assert.assertEquals(partitionedStepName, ws.getCurrentActivityName());
         Assert.assertEquals(StepResult.SUCCEED_RESULT_CODE, ws.getCurrentStepResultCode());
-        Assert.assertEquals(OffsetDateTime.ofInstant(p1Start1.eventTimestamp(), ZoneOffset.UTC), ws.getCurrentStepFirstScheduledTime());
-        Assert.assertEquals(OffsetDateTime.ofInstant(p2End3.eventTimestamp(), ZoneOffset.UTC), ws.getCurrentStepCompletionTime());
+        Assert.assertEquals(p1Start1.eventTimestamp(), ws.getCurrentStepFirstScheduledTime());
+        Assert.assertEquals(p2End3.eventTimestamp(), ws.getCurrentStepCompletionTime());
         Assert.assertEquals(2L, (long)ws.getCurrentStepMaxRetryCount());
 
         Assert.assertNotNull(ws.getStepPartitions());
@@ -785,7 +782,7 @@ public class WorkflowStateTest {
 
         WorkflowState ws = history.buildCurrentState();
 
-        Assert.assertEquals(OffsetDateTime.ofInstant(now, ZoneOffset.UTC), ws.getWorkflowStartDate());
+        Assert.assertEquals(now, ws.getWorkflowStartDate());
         Assert.assertEquals(input, ws.getWorkflowInput());
         Assert.assertTrue(ws.getOpenTimers().isEmpty());
         Assert.assertEquals(4, ws.getClosedTimers().size()); // two retries each for two partitions
@@ -801,8 +798,8 @@ public class WorkflowStateTest {
         Assert.assertEquals(partitionedStepName, ws.getCurrentActivityName());
         // the effectiveResultCode should be _fail as one of the partitions has failed
         Assert.assertEquals(StepResult.FAIL_RESULT_CODE, ws.getCurrentStepResultCode());
-        Assert.assertEquals(OffsetDateTime.ofInstant(p1Start1.eventTimestamp(), ZoneOffset.UTC), ws.getCurrentStepFirstScheduledTime());
-        Assert.assertEquals(OffsetDateTime.ofInstant(p2End3.eventTimestamp(), ZoneOffset.UTC), ws.getCurrentStepCompletionTime());
+        Assert.assertEquals(p1Start1.eventTimestamp(), ws.getCurrentStepFirstScheduledTime());
+        Assert.assertEquals(p2End3.eventTimestamp(), ws.getCurrentStepCompletionTime());
         Assert.assertEquals(2L, (long)ws.getCurrentStepMaxRetryCount());
 
         Assert.assertNotNull(ws.getStepPartitions());
@@ -833,7 +830,7 @@ public class WorkflowStateTest {
         history.recordActivityTimedOut();
         WorkflowState ws = history.buildCurrentState();
 
-        Assert.assertEquals(OffsetDateTime.ofInstant(now, ZoneOffset.UTC), ws.getWorkflowStartDate());
+        Assert.assertEquals(now, ws.getWorkflowStartDate());
         Assert.assertEquals(input, ws.getWorkflowInput());
         Assert.assertTrue(ws.getOpenTimers().isEmpty());
         Assert.assertTrue(ws.getClosedTimers().isEmpty());
@@ -844,7 +841,7 @@ public class WorkflowStateTest {
 
         Assert.assertEquals(firstActivityName, ws.getCurrentActivityName());
         Assert.assertNull(ws.getCurrentStepResultCode());
-        Assert.assertEquals(OffsetDateTime.ofInstant(startEvent.eventTimestamp(), ZoneOffset.UTC), ws.getCurrentStepFirstScheduledTime());
+        Assert.assertEquals(startEvent.eventTimestamp(), ws.getCurrentStepFirstScheduledTime());
         Assert.assertNull(ws.getCurrentStepCompletionTime());
         Assert.assertEquals(0L, (long)ws.getCurrentStepMaxRetryCount());
 
@@ -873,7 +870,7 @@ public class WorkflowStateTest {
         history.recordActivityCanceled();
         WorkflowState ws = history.buildCurrentState();
 
-        Assert.assertEquals(OffsetDateTime.ofInstant(now, ZoneOffset.UTC), ws.getWorkflowStartDate());
+        Assert.assertEquals(now, ws.getWorkflowStartDate());
         Assert.assertEquals(input, ws.getWorkflowInput());
         Assert.assertTrue(ws.getOpenTimers().isEmpty());
         Assert.assertTrue(ws.getClosedTimers().isEmpty());
@@ -884,7 +881,7 @@ public class WorkflowStateTest {
 
         Assert.assertEquals(firstActivityName, ws.getCurrentActivityName());
         Assert.assertNull(ws.getCurrentStepResultCode());
-        Assert.assertEquals(OffsetDateTime.ofInstant(startEvent.eventTimestamp(), ZoneOffset.UTC), ws.getCurrentStepFirstScheduledTime());
+        Assert.assertEquals(startEvent.eventTimestamp(), ws.getCurrentStepFirstScheduledTime());
         Assert.assertNull(ws.getCurrentStepCompletionTime());
         Assert.assertEquals(0L, (long)ws.getCurrentStepMaxRetryCount());
 
@@ -920,7 +917,7 @@ public class WorkflowStateTest {
 
         WorkflowState ws = history.buildCurrentState();
 
-        Assert.assertEquals(OffsetDateTime.ofInstant(now, ZoneOffset.UTC), ws.getWorkflowStartDate());
+        Assert.assertEquals(now, ws.getWorkflowStartDate());
         Assert.assertEquals(input, ws.getWorkflowInput());
         Assert.assertTrue(ws.getOpenTimers().isEmpty());
         Assert.assertEquals(1, ws.getClosedTimers().size());
@@ -932,8 +929,8 @@ public class WorkflowStateTest {
 
         Assert.assertEquals(firstActivityName, ws.getCurrentActivityName());
         Assert.assertEquals(StepResult.SUCCEED_RESULT_CODE, ws.getCurrentStepResultCode());
-        Assert.assertEquals(OffsetDateTime.ofInstant(firstStart.eventTimestamp(), ZoneOffset.UTC), ws.getCurrentStepFirstScheduledTime());
-        Assert.assertEquals(OffsetDateTime.ofInstant(secondClose.eventTimestamp(), ZoneOffset.UTC), ws.getCurrentStepCompletionTime());
+        Assert.assertEquals(firstStart.eventTimestamp(), ws.getCurrentStepFirstScheduledTime());
+        Assert.assertEquals(secondClose.eventTimestamp(), ws.getCurrentStepCompletionTime());
         Assert.assertEquals(1L, (long)ws.getCurrentStepMaxRetryCount());
 
         Assert.assertNotNull(ws.getStepPartitions());
@@ -966,7 +963,7 @@ public class WorkflowStateTest {
 
         WorkflowState ws = history.buildCurrentState();
 
-        Assert.assertEquals(OffsetDateTime.ofInstant(now, ZoneOffset.UTC), ws.getWorkflowStartDate());
+        Assert.assertEquals(now, ws.getWorkflowStartDate());
         Assert.assertEquals(input, ws.getWorkflowInput());
         Assert.assertTrue(ws.getOpenTimers().isEmpty());
         Assert.assertTrue(ws.getClosedTimers().isEmpty());
@@ -977,8 +974,8 @@ public class WorkflowStateTest {
 
         Assert.assertEquals(secondActivityName, ws.getCurrentActivityName());
         Assert.assertEquals(StepResult.SUCCEED_RESULT_CODE, ws.getCurrentStepResultCode());
-        Assert.assertEquals(OffsetDateTime.ofInstant(secondStart.eventTimestamp(), ZoneOffset.UTC), ws.getCurrentStepFirstScheduledTime());
-        Assert.assertEquals(OffsetDateTime.ofInstant(secondClose.eventTimestamp(), ZoneOffset.UTC), ws.getCurrentStepCompletionTime());
+        Assert.assertEquals(secondStart.eventTimestamp(), ws.getCurrentStepFirstScheduledTime());
+        Assert.assertEquals(secondClose.eventTimestamp(), ws.getCurrentStepCompletionTime());
         Assert.assertEquals(0L, (long)ws.getCurrentStepMaxRetryCount());
 
         Assert.assertNotNull(ws.getStepPartitions());
@@ -1014,7 +1011,7 @@ public class WorkflowStateTest {
 
         WorkflowState ws = history.buildCurrentState();
 
-        Assert.assertEquals(OffsetDateTime.ofInstant(now, ZoneOffset.UTC), ws.getWorkflowStartDate());
+        Assert.assertEquals(now, ws.getWorkflowStartDate());
         Assert.assertEquals(input, ws.getWorkflowInput());
 
         Assert.assertEquals(1, ws.getOpenTimers().size());
@@ -1030,7 +1027,7 @@ public class WorkflowStateTest {
         Assert.assertEquals(firstActivityName, ws.getCurrentActivityName());
         Assert.assertNull(ws.getCurrentStepResultCode());
         Assert.assertNull(ws.getCurrentStepLastActivityCompletionMessage());
-        Assert.assertEquals(firstStart.eventTimestamp(), ws.getCurrentStepFirstScheduledTime().toInstant());
+        Assert.assertEquals(firstStart.eventTimestamp(), ws.getCurrentStepFirstScheduledTime());
         Assert.assertNull(ws.getCurrentStepCompletionTime());
         Assert.assertEquals(0L, ws.getCurrentStepMaxRetryCount().longValue());
 
@@ -1059,7 +1056,7 @@ public class WorkflowStateTest {
 
         WorkflowState ws = history.buildCurrentState();
 
-        Assert.assertEquals(OffsetDateTime.ofInstant(now, ZoneOffset.UTC), ws.getWorkflowStartDate());
+        Assert.assertEquals(now, ws.getWorkflowStartDate());
         Assert.assertEquals(input, ws.getWorkflowInput());
         Assert.assertTrue(ws.getOpenTimers().isEmpty());
 
@@ -1073,7 +1070,7 @@ public class WorkflowStateTest {
 
         Assert.assertEquals(firstActivityName, ws.getCurrentActivityName());
         Assert.assertNull(ws.getCurrentStepResultCode());
-        Assert.assertEquals(firstStart.eventTimestamp(), ws.getCurrentStepFirstScheduledTime().toInstant());
+        Assert.assertEquals(firstStart.eventTimestamp(), ws.getCurrentStepFirstScheduledTime());
         Assert.assertNull(ws.getCurrentStepCompletionTime());
         Assert.assertEquals(0L, ws.getCurrentStepMaxRetryCount().longValue());
 
@@ -1103,7 +1100,7 @@ public class WorkflowStateTest {
 
         WorkflowState ws = history.buildCurrentState();
 
-        Assert.assertEquals(OffsetDateTime.ofInstant(now, ZoneOffset.UTC), ws.getWorkflowStartDate());
+        Assert.assertEquals(now, ws.getWorkflowStartDate());
         Assert.assertEquals(input, ws.getWorkflowInput());
         Assert.assertTrue(ws.getOpenTimers().isEmpty());
 
@@ -1117,7 +1114,7 @@ public class WorkflowStateTest {
 
         Assert.assertEquals(firstActivityName, ws.getCurrentActivityName());
         Assert.assertNull(ws.getCurrentStepResultCode());
-        Assert.assertEquals(firstStart.eventTimestamp(), ws.getCurrentStepFirstScheduledTime().toInstant());
+        Assert.assertEquals(firstStart.eventTimestamp(), ws.getCurrentStepFirstScheduledTime());
         Assert.assertNull(ws.getCurrentStepCompletionTime());
         Assert.assertEquals(0L, ws.getCurrentStepMaxRetryCount().longValue());
 
@@ -1149,7 +1146,7 @@ public class WorkflowStateTest {
 
         WorkflowState ws = history.buildCurrentState();
 
-        Assert.assertEquals(OffsetDateTime.ofInstant(now, ZoneOffset.UTC), ws.getWorkflowStartDate());
+        Assert.assertEquals(now, ws.getWorkflowStartDate());
         Assert.assertEquals(input, ws.getWorkflowInput());
 
         Assert.assertTrue(ws.getOpenTimers().containsKey(timerRestart.timerStartedEventAttributes().timerId()));
@@ -1162,7 +1159,7 @@ public class WorkflowStateTest {
 
         Assert.assertEquals(firstActivityName, ws.getCurrentActivityName());
         Assert.assertNull(ws.getCurrentStepResultCode());
-        Assert.assertEquals(firstStart.eventTimestamp(), ws.getCurrentStepFirstScheduledTime().toInstant());
+        Assert.assertEquals(firstStart.eventTimestamp(), ws.getCurrentStepFirstScheduledTime());
         Assert.assertNull(ws.getCurrentStepCompletionTime());
         Assert.assertEquals(0L, ws.getCurrentStepMaxRetryCount().longValue());
 
@@ -1194,7 +1191,7 @@ public class WorkflowStateTest {
 
         WorkflowState ws = history.buildCurrentState();
 
-        Assert.assertEquals(OffsetDateTime.ofInstant(now, ZoneOffset.UTC), ws.getWorkflowStartDate());
+        Assert.assertEquals(now, ws.getWorkflowStartDate());
         Assert.assertEquals(input, ws.getWorkflowInput());
 
         Assert.assertTrue(ws.getOpenTimers().isEmpty());
@@ -1208,7 +1205,7 @@ public class WorkflowStateTest {
 
         Assert.assertEquals(firstActivityName, ws.getCurrentActivityName());
         Assert.assertNull(ws.getCurrentStepResultCode());
-        Assert.assertEquals(firstStart.eventTimestamp(), ws.getCurrentStepFirstScheduledTime().toInstant());
+        Assert.assertEquals(firstStart.eventTimestamp(), ws.getCurrentStepFirstScheduledTime());
         Assert.assertNull(ws.getCurrentStepCompletionTime());
         Assert.assertEquals(0L, ws.getCurrentStepMaxRetryCount().longValue());
 
@@ -1237,7 +1234,7 @@ public class WorkflowStateTest {
 
         WorkflowState ws = history.buildCurrentState();
 
-        Assert.assertEquals(OffsetDateTime.ofInstant(now, ZoneOffset.UTC), ws.getWorkflowStartDate());
+        Assert.assertEquals(now, ws.getWorkflowStartDate());
         Assert.assertEquals(input, ws.getWorkflowInput());
 
         Assert.assertTrue(ws.getSignalsByActivityId().containsKey(timerStart.timerStartedEventAttributes().timerId()));
@@ -1255,8 +1252,7 @@ public class WorkflowStateTest {
         Assert.assertEquals(firstActivityName, ws.getCurrentActivityName());
         Assert.assertNull(ws.getCurrentStepResultCode());
         Assert.assertNull(ws.getCurrentStepLastActivityCompletionMessage());
-        Assert.assertEquals(OffsetDateTime.ofInstant(firstStart.eventTimestamp(), ZoneOffset.UTC),
-                            ws.getCurrentStepFirstScheduledTime());
+        Assert.assertEquals(firstStart.eventTimestamp(), ws.getCurrentStepFirstScheduledTime());
         Assert.assertNull(ws.getCurrentStepCompletionTime());
 
         Assert.assertNotNull(ws.getStepPartitions());
@@ -1288,7 +1284,7 @@ public class WorkflowStateTest {
 
         WorkflowState ws = history.buildCurrentState();
 
-        Assert.assertEquals(OffsetDateTime.ofInstant(now, ZoneOffset.UTC), ws.getWorkflowStartDate());
+        Assert.assertEquals(now, ws.getWorkflowStartDate());
         Assert.assertEquals(input, ws.getWorkflowInput());
 
         Assert.assertTrue(ws.getSignalsByActivityId().containsKey(timerStart.timerStartedEventAttributes().timerId()));
@@ -1306,8 +1302,7 @@ public class WorkflowStateTest {
         Assert.assertEquals(firstActivityName, ws.getCurrentActivityName());
         Assert.assertNull(ws.getCurrentStepResultCode());
         Assert.assertNull(ws.getCurrentStepLastActivityCompletionMessage());
-        Assert.assertEquals(OffsetDateTime.ofInstant(firstStart.eventTimestamp(), ZoneOffset.UTC),
-                            ws.getCurrentStepFirstScheduledTime());
+        Assert.assertEquals(firstStart.eventTimestamp(), ws.getCurrentStepFirstScheduledTime());
         Assert.assertNull(ws.getCurrentStepCompletionTime());
 
         Assert.assertNotNull(ws.getStepPartitions());
@@ -1338,7 +1333,7 @@ public class WorkflowStateTest {
 
         WorkflowState ws = history.buildCurrentState();
 
-        Assert.assertEquals(OffsetDateTime.ofInstant(now, ZoneOffset.UTC), ws.getWorkflowStartDate());
+        Assert.assertEquals(now, ws.getWorkflowStartDate());
         Assert.assertEquals(input, ws.getWorkflowInput());
 
         Assert.assertTrue(ws.getSignalsByActivityId().isEmpty());
@@ -1354,8 +1349,7 @@ public class WorkflowStateTest {
         Assert.assertEquals(firstActivityName, ws.getCurrentActivityName());
         Assert.assertNull(ws.getCurrentStepResultCode());
         Assert.assertNull(ws.getCurrentStepLastActivityCompletionMessage());
-        Assert.assertEquals(OffsetDateTime.ofInstant(firstStart.eventTimestamp(), ZoneOffset.UTC),
-                            ws.getCurrentStepFirstScheduledTime());
+        Assert.assertEquals(firstStart.eventTimestamp(), ws.getCurrentStepFirstScheduledTime());
         Assert.assertNull(ws.getCurrentStepCompletionTime());
 
         Assert.assertNotNull(ws.getStepPartitions());
@@ -1383,7 +1377,7 @@ public class WorkflowStateTest {
 
         WorkflowState ws = history.buildCurrentState();
 
-        Assert.assertEquals(OffsetDateTime.ofInstant(now, ZoneOffset.UTC), ws.getWorkflowStartDate());
+        Assert.assertEquals(now, ws.getWorkflowStartDate());
         Assert.assertEquals(input, ws.getWorkflowInput());
 
         Assert.assertTrue(ws.getSignalsByActivityId().containsKey(timerStart.timerStartedEventAttributes().timerId()));
@@ -1402,8 +1396,7 @@ public class WorkflowStateTest {
         Assert.assertEquals(firstActivityName, ws.getCurrentActivityName());
         Assert.assertNull(ws.getCurrentStepResultCode());
         Assert.assertNull(ws.getCurrentStepLastActivityCompletionMessage());
-        Assert.assertEquals(OffsetDateTime.ofInstant(firstStart.eventTimestamp(), ZoneOffset.UTC),
-                            ws.getCurrentStepFirstScheduledTime());
+        Assert.assertEquals(firstStart.eventTimestamp(), ws.getCurrentStepFirstScheduledTime());
         Assert.assertNull(ws.getCurrentStepCompletionTime());
 
         Assert.assertNotNull(ws.getStepPartitions());
@@ -1432,7 +1425,7 @@ public class WorkflowStateTest {
 
         WorkflowState ws = history.buildCurrentState();
 
-        Assert.assertEquals(OffsetDateTime.ofInstant(now, ZoneOffset.UTC), ws.getWorkflowStartDate());
+        Assert.assertEquals(now, ws.getWorkflowStartDate());
         Assert.assertEquals(input, ws.getWorkflowInput());
 
         Assert.assertTrue(ws.getSignalsByActivityId().containsKey(timerStart.timerStartedEventAttributes().timerId()));
@@ -1451,8 +1444,7 @@ public class WorkflowStateTest {
         Assert.assertEquals(firstActivityName, ws.getCurrentActivityName());
         Assert.assertNull(ws.getCurrentStepResultCode());
         Assert.assertNull(ws.getCurrentStepLastActivityCompletionMessage());
-        Assert.assertEquals(OffsetDateTime.ofInstant(firstStart.eventTimestamp(), ZoneOffset.UTC),
-                            ws.getCurrentStepFirstScheduledTime());
+        Assert.assertEquals(firstStart.eventTimestamp(), ws.getCurrentStepFirstScheduledTime());
         Assert.assertNull(ws.getCurrentStepCompletionTime());
 
         Assert.assertNotNull(ws.getStepPartitions());
@@ -1480,7 +1472,7 @@ public class WorkflowStateTest {
 
         WorkflowState ws = history.buildCurrentState();
 
-        Assert.assertEquals(OffsetDateTime.ofInstant(now, ZoneOffset.UTC), ws.getWorkflowStartDate());
+        Assert.assertEquals(now, ws.getWorkflowStartDate());
         Assert.assertEquals(input, ws.getWorkflowInput());
 
         Assert.assertTrue(ws.getSignalsByActivityId().containsKey(timerStart.timerStartedEventAttributes().timerId()));
@@ -1499,10 +1491,8 @@ public class WorkflowStateTest {
         Assert.assertEquals(firstActivityName, ws.getCurrentActivityName());
         Assert.assertEquals(StepResult.FAIL_RESULT_CODE, ws.getCurrentStepResultCode());
         Assert.assertEquals(WorkflowState.FORCED_RESULT_MESSAGE, ws.getCurrentStepLastActivityCompletionMessage());
-        Assert.assertEquals(OffsetDateTime.ofInstant(firstStart.eventTimestamp(), ZoneOffset.UTC),
-                            ws.getCurrentStepFirstScheduledTime());
-        Assert.assertEquals(OffsetDateTime.ofInstant(signal.eventTimestamp(), ZoneOffset.UTC),
-                            ws.getCurrentStepCompletionTime());
+        Assert.assertEquals(firstStart.eventTimestamp(), ws.getCurrentStepFirstScheduledTime());
+        Assert.assertEquals(signal.eventTimestamp(), ws.getCurrentStepCompletionTime());
 
         Assert.assertNotNull(ws.getStepPartitions());
         Assert.assertEquals(1, ws.getStepPartitions().size());
@@ -1530,7 +1520,7 @@ public class WorkflowStateTest {
 
         WorkflowState ws = history.buildCurrentState();
 
-        Assert.assertEquals(OffsetDateTime.ofInstant(now, ZoneOffset.UTC), ws.getWorkflowStartDate());
+        Assert.assertEquals(now, ws.getWorkflowStartDate());
         Assert.assertEquals(input, ws.getWorkflowInput());
 
         Assert.assertTrue(ws.getSignalsByActivityId().containsKey(timerStart.timerStartedEventAttributes().timerId()));
@@ -1549,8 +1539,7 @@ public class WorkflowStateTest {
         Assert.assertEquals(firstActivityName, ws.getCurrentActivityName());
         Assert.assertNull(ws.getCurrentStepResultCode());
         Assert.assertNull(ws.getCurrentStepLastActivityCompletionMessage());
-        Assert.assertEquals(OffsetDateTime.ofInstant(firstStart.eventTimestamp(), ZoneOffset.UTC),
-                            ws.getCurrentStepFirstScheduledTime());
+        Assert.assertEquals(firstStart.eventTimestamp(), ws.getCurrentStepFirstScheduledTime());
         Assert.assertNull(ws.getCurrentStepCompletionTime());
 
         Assert.assertNotNull(ws.getStepPartitions());
@@ -1581,7 +1570,7 @@ public class WorkflowStateTest {
 
         WorkflowState ws = history.buildCurrentState();
 
-        Assert.assertEquals(OffsetDateTime.ofInstant(now, ZoneOffset.UTC), ws.getWorkflowStartDate());
+        Assert.assertEquals(now, ws.getWorkflowStartDate());
         Assert.assertEquals(input, ws.getWorkflowInput());
 
         Assert.assertTrue(ws.getSignalsByActivityId().isEmpty());
@@ -1597,8 +1586,7 @@ public class WorkflowStateTest {
         Assert.assertEquals(firstActivityName, ws.getCurrentActivityName());
         Assert.assertNull(ws.getCurrentStepResultCode());
         Assert.assertNull(ws.getCurrentStepLastActivityCompletionMessage());
-        Assert.assertEquals(OffsetDateTime.ofInstant(firstStart.eventTimestamp(), ZoneOffset.UTC),
-                            ws.getCurrentStepFirstScheduledTime());
+        Assert.assertEquals(firstStart.eventTimestamp(), ws.getCurrentStepFirstScheduledTime());
         Assert.assertNull(ws.getCurrentStepCompletionTime());
 
         Assert.assertNotNull(ws.getStepPartitions());
@@ -1627,7 +1615,7 @@ public class WorkflowStateTest {
 
         WorkflowState ws = history.buildCurrentState();
 
-        Assert.assertEquals(OffsetDateTime.ofInstant(now, ZoneOffset.UTC), ws.getWorkflowStartDate());
+        Assert.assertEquals(now, ws.getWorkflowStartDate());
         Assert.assertEquals(input, ws.getWorkflowInput());
 
         Assert.assertTrue(ws.getSignalsByActivityId().isEmpty());
@@ -1643,8 +1631,7 @@ public class WorkflowStateTest {
         Assert.assertEquals(firstActivityName, ws.getCurrentActivityName());
         Assert.assertNull(ws.getCurrentStepResultCode());
         Assert.assertNull(ws.getCurrentStepLastActivityCompletionMessage());
-        Assert.assertEquals(OffsetDateTime.ofInstant(firstStart.eventTimestamp(), ZoneOffset.UTC),
-                            ws.getCurrentStepFirstScheduledTime());
+        Assert.assertEquals(firstStart.eventTimestamp(), ws.getCurrentStepFirstScheduledTime());
         Assert.assertNull(ws.getCurrentStepCompletionTime());
 
         Assert.assertNotNull(ws.getStepPartitions());
@@ -1667,14 +1654,13 @@ public class WorkflowStateTest {
 
         WorkflowState ws = history.buildCurrentState();
 
-        Assert.assertEquals(OffsetDateTime.ofInstant(now, ZoneOffset.UTC), ws.getWorkflowStartDate());
+        Assert.assertEquals(now, ws.getWorkflowStartDate());
         Assert.assertEquals(input, ws.getWorkflowInput());
         Assert.assertTrue(ws.getOpenTimers().isEmpty());
         Assert.assertTrue(ws.getClosedTimers().isEmpty());
 
         Assert.assertTrue(ws.isWorkflowCancelRequested());
-        Assert.assertEquals(OffsetDateTime.ofInstant(cancelEvent.eventTimestamp(), ZoneOffset.UTC),
-                            ws.getWorkflowCancelRequestDate());
+        Assert.assertEquals(cancelEvent.eventTimestamp(), ws.getWorkflowCancelRequestDate());
         Assert.assertFalse(ws.isWorkflowExecutionClosed());
 
         Assert.assertNull(ws.getCurrentActivityName());
@@ -1703,19 +1689,17 @@ public class WorkflowStateTest {
 
         WorkflowState ws = history.buildCurrentState();
 
-        Assert.assertEquals(OffsetDateTime.ofInstant(now, ZoneOffset.UTC), ws.getWorkflowStartDate());
+        Assert.assertEquals(now, ws.getWorkflowStartDate());
         Assert.assertEquals(input, ws.getWorkflowInput());
         Assert.assertTrue(ws.getOpenTimers().isEmpty());
         Assert.assertTrue(ws.getClosedTimers().isEmpty());
 
         Assert.assertTrue(ws.isWorkflowCancelRequested());
-        Assert.assertEquals(OffsetDateTime.ofInstant(cancelEvent.eventTimestamp(), ZoneOffset.UTC),
-                            ws.getWorkflowCancelRequestDate());
+        Assert.assertEquals(cancelEvent.eventTimestamp(), ws.getWorkflowCancelRequestDate());
         Assert.assertFalse(ws.isWorkflowExecutionClosed());
 
         Assert.assertEquals(firstActivityName, ws.getCurrentActivityName());
-        Assert.assertEquals(OffsetDateTime.ofInstant(stepStart.eventTimestamp(), ZoneOffset.UTC),
-                            ws.getCurrentStepFirstScheduledTime());
+        Assert.assertEquals(stepStart.eventTimestamp(), ws.getCurrentStepFirstScheduledTime());
         Assert.assertEquals(0, (long)ws.getCurrentStepMaxRetryCount());
         Assert.assertNull(ws.getCurrentStepResultCode());
 
@@ -1740,14 +1724,13 @@ public class WorkflowStateTest {
 
         WorkflowState ws = history.buildCurrentState();
 
-        Assert.assertEquals(OffsetDateTime.ofInstant(now, ZoneOffset.UTC), ws.getWorkflowStartDate());
+        Assert.assertEquals(now, ws.getWorkflowStartDate());
         Assert.assertEquals(input, ws.getWorkflowInput());
         Assert.assertTrue(ws.getOpenTimers().isEmpty());
         Assert.assertTrue(ws.getClosedTimers().isEmpty());
 
         Assert.assertTrue(ws.isWorkflowCancelRequested());
-        Assert.assertEquals(OffsetDateTime.ofInstant(cancelRequestEvent.eventTimestamp(), ZoneOffset.UTC),
-                            ws.getWorkflowCancelRequestDate());
+        Assert.assertEquals(cancelRequestEvent.eventTimestamp(), ws.getWorkflowCancelRequestDate());
         Assert.assertTrue(ws.isWorkflowExecutionClosed());
 
         Assert.assertNull(ws.getCurrentActivityName());
@@ -1781,7 +1764,7 @@ public class WorkflowStateTest {
 
         WorkflowState ws = history.buildCurrentState();
 
-        Assert.assertEquals(OffsetDateTime.ofInstant(now, ZoneOffset.UTC), ws.getWorkflowStartDate());
+        Assert.assertEquals(now, ws.getWorkflowStartDate());
         Assert.assertEquals(input, ws.getWorkflowInput());
         Assert.assertTrue(ws.getOpenTimers().isEmpty());
         Assert.assertTrue(ws.getClosedTimers().isEmpty());
@@ -1792,10 +1775,8 @@ public class WorkflowStateTest {
 
         Assert.assertEquals(secondActivityName, ws.getCurrentActivityName());
         Assert.assertEquals(StepResult.SUCCEED_RESULT_CODE, ws.getCurrentStepResultCode());
-        Assert.assertEquals(OffsetDateTime.ofInstant(stepTwoStart.eventTimestamp(), ZoneOffset.UTC),
-                            ws.getCurrentStepFirstScheduledTime());
-        Assert.assertEquals(OffsetDateTime.ofInstant(stepTwoEnd.eventTimestamp(), ZoneOffset.UTC),
-                            ws.getCurrentStepCompletionTime());
+        Assert.assertEquals(stepTwoStart.eventTimestamp(), ws.getCurrentStepFirstScheduledTime());
+        Assert.assertEquals(stepTwoEnd.eventTimestamp(), ws.getCurrentStepCompletionTime());
         Assert.assertEquals(0L, (long)ws.getCurrentStepMaxRetryCount());
 
         Assert.assertNotNull(ws.getStepPartitions());
@@ -1836,7 +1817,7 @@ public class WorkflowStateTest {
 
         WorkflowState ws = history.buildCurrentState();
 
-        Assert.assertEquals(OffsetDateTime.ofInstant(now, ZoneOffset.UTC), ws.getWorkflowStartDate());
+        Assert.assertEquals(now, ws.getWorkflowStartDate());
         Assert.assertEquals(input, ws.getWorkflowInput());
         Assert.assertTrue(ws.getOpenTimers().isEmpty());
         Assert.assertTrue(ws.getClosedTimers().isEmpty());
@@ -1847,10 +1828,8 @@ public class WorkflowStateTest {
 
         Assert.assertEquals(secondActivityName, ws.getCurrentActivityName());
         Assert.assertEquals(StepResult.FAIL_RESULT_CODE, ws.getCurrentStepResultCode());
-        Assert.assertEquals(OffsetDateTime.ofInstant(stepTwoStart.eventTimestamp(), ZoneOffset.UTC),
-                ws.getCurrentStepFirstScheduledTime());
-        Assert.assertEquals(OffsetDateTime.ofInstant(stepTwoEnd.eventTimestamp(), ZoneOffset.UTC),
-                ws.getCurrentStepCompletionTime());
+        Assert.assertEquals(stepTwoStart.eventTimestamp(), ws.getCurrentStepFirstScheduledTime());
+        Assert.assertEquals(stepTwoEnd.eventTimestamp(), ws.getCurrentStepCompletionTime());
         Assert.assertEquals(0L, (long)ws.getCurrentStepMaxRetryCount());
 
         Assert.assertNotNull(ws.getStepPartitions());
@@ -1883,7 +1862,7 @@ public class WorkflowStateTest {
 
         WorkflowState ws = history.buildCurrentState();
 
-        Assert.assertEquals(OffsetDateTime.ofInstant(now, ZoneOffset.UTC), ws.getWorkflowStartDate());
+        Assert.assertEquals(now, ws.getWorkflowStartDate());
         Assert.assertEquals(input, ws.getWorkflowInput());
         Assert.assertTrue(ws.getOpenTimers().isEmpty());
         Assert.assertTrue(ws.getClosedTimers().isEmpty());
@@ -1915,7 +1894,7 @@ public class WorkflowStateTest {
 
         WorkflowState ws = history.buildCurrentState();
 
-        Assert.assertEquals(OffsetDateTime.ofInstant(now, ZoneOffset.UTC), ws.getWorkflowStartDate());
+        Assert.assertEquals(now, ws.getWorkflowStartDate());
         Assert.assertEquals(input, ws.getWorkflowInput());
         Assert.assertTrue(ws.getOpenTimers().isEmpty());
         Assert.assertTrue(ws.getClosedTimers().isEmpty());
@@ -2098,11 +2077,11 @@ public class WorkflowStateTest {
         for (int i = 0; i < attemptStartTimes.size(); i++) {
             PartitionState attempt = ws.getStepPartitions().get(stepName).get(partitionId).get(i);
 
-            Assert.assertEquals(OffsetDateTime.ofInstant(attemptStartTimes.get(i), ZoneOffset.UTC), attempt.getAttemptScheduledTime());
+            Assert.assertEquals(attemptStartTimes.get(i), attempt.getAttemptScheduledTime());
             Map<String, String> attemptInput = new HashMap<>(initialInput);
             attemptInput.put(StepAttributes.WORKFLOW_ID, StepAttributes.encode(ws.getWorkflowId()));
             attemptInput.put(StepAttributes.WORKFLOW_EXECUTION_ID, StepAttributes.encode(ws.getWorkflowRunId()));
-            attemptInput.put(StepAttributes.WORKFLOW_START_TIME, StepAttributes.encode(Date.from(ws.getWorkflowStartDate().toInstant())));
+            attemptInput.put(StepAttributes.WORKFLOW_START_TIME, StepAttributes.encode(ws.getWorkflowStartDate()));
             if (i > 0) {
                 attemptInput.put(StepAttributes.RETRY_ATTEMPT, Long.toString(i));
             }

--- a/flux/src/test/java/software/amazon/aws/clients/swf/flux/poller/testwf/TestStepExpectsStartTimeAttributesAsDate.java
+++ b/flux/src/test/java/software/amazon/aws/clients/swf/flux/poller/testwf/TestStepExpectsStartTimeAttributesAsDate.java
@@ -1,0 +1,32 @@
+/*
+ *   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package software.amazon.aws.clients.swf.flux.poller.testwf;
+
+import java.util.Date;
+
+import software.amazon.aws.clients.swf.flux.step.Attribute;
+import software.amazon.aws.clients.swf.flux.step.StepApply;
+import software.amazon.aws.clients.swf.flux.step.StepAttributes;
+import software.amazon.aws.clients.swf.flux.step.WorkflowStep;
+
+public class TestStepExpectsStartTimeAttributesAsDate implements WorkflowStep {
+
+    @StepApply
+    public void apply(@Attribute(StepAttributes.WORKFLOW_START_TIME) Date workflowStart,
+                      @Attribute(StepAttributes.ACTIVITY_INITIAL_ATTEMPT_TIME) Date activityInitialStart) {
+    }
+}

--- a/flux/src/test/java/software/amazon/aws/clients/swf/flux/poller/testwf/TestStepExpectsStartTimeAttributesAsInstant.java
+++ b/flux/src/test/java/software/amazon/aws/clients/swf/flux/poller/testwf/TestStepExpectsStartTimeAttributesAsInstant.java
@@ -1,0 +1,32 @@
+/*
+ *   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package software.amazon.aws.clients.swf.flux.poller.testwf;
+
+import java.time.Instant;
+
+import software.amazon.aws.clients.swf.flux.step.Attribute;
+import software.amazon.aws.clients.swf.flux.step.StepApply;
+import software.amazon.aws.clients.swf.flux.step.StepAttributes;
+import software.amazon.aws.clients.swf.flux.step.WorkflowStep;
+
+public class TestStepExpectsStartTimeAttributesAsInstant implements WorkflowStep {
+
+    @StepApply
+    public void apply(@Attribute(StepAttributes.WORKFLOW_START_TIME) Instant workflowStart,
+                      @Attribute(StepAttributes.ACTIVITY_INITIAL_ATTEMPT_TIME) Instant activityInitialStart) {
+    }
+}

--- a/flux/src/test/java/software/amazon/aws/clients/swf/flux/wf/graph/WorkflowGraphBuilderTest.java
+++ b/flux/src/test/java/software/amazon/aws/clients/swf/flux/wf/graph/WorkflowGraphBuilderTest.java
@@ -37,6 +37,8 @@ import software.amazon.aws.clients.swf.flux.poller.testwf.TestPartitionedStepWit
 import software.amazon.aws.clients.swf.flux.poller.testwf.TestStepAlsoDeclaresOutputAttribute;
 import software.amazon.aws.clients.swf.flux.poller.testwf.TestStepDeclaresOutputAttribute;
 import software.amazon.aws.clients.swf.flux.poller.testwf.TestStepExpectsLongInputAttribute;
+import software.amazon.aws.clients.swf.flux.poller.testwf.TestStepExpectsStartTimeAttributesAsDate;
+import software.amazon.aws.clients.swf.flux.poller.testwf.TestStepExpectsStartTimeAttributesAsInstant;
 import software.amazon.aws.clients.swf.flux.poller.testwf.TestStepHasInputAttribute;
 import software.amazon.aws.clients.swf.flux.poller.testwf.TestStepHasOptionalInputAttribute;
 import software.amazon.aws.clients.swf.flux.poller.testwf.TestStepOne;
@@ -1437,6 +1439,26 @@ public class WorkflowGraphBuilderTest {
 
         builder.addStep(end);
         builder.alwaysClose(end);
+
+        Assert.assertNotNull(builder.build());
+    }
+
+    @Test
+    public void build_DoesValidateAttributeInputsIfInitialInputAttributesSpecified_AllowsStartTimeAttributesAsDate() {
+        WorkflowStep start = new TestStepExpectsStartTimeAttributesAsDate();
+
+        WorkflowGraphBuilder builder = new WorkflowGraphBuilder(start, Collections.emptyMap());
+        builder.alwaysClose(start);
+
+        Assert.assertNotNull(builder.build());
+    }
+
+    @Test
+    public void build_DoesValidateAttributeInputsIfInitialInputAttributesSpecified_AllowsStartTimeAttributesAsInstant() {
+        WorkflowStep start = new TestStepExpectsStartTimeAttributesAsInstant();
+
+        WorkflowGraphBuilder builder = new WorkflowGraphBuilder(start, Collections.emptyMap());
+        builder.alwaysClose(start);
 
         Assert.assertNotNull(builder.build());
     }


### PR DESCRIPTION
* Add support for Instant as an input and output attribute.
* Improve the unit tests for the StepAttributes class.

https://github.com/awslabs/flux-swf-client/issues/19



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
