### PR TITLE
FluxCapacitorConfig now takes a ClientOverrideConfiguration to pass to the SwfClient on initialization.

### DIFF
--- a/flux-integration-tests/src/test/java/software/amazon/aws/clients/swf/flux/tests/CustomSdkConfigurationTest.java
+++ b/flux-integration-tests/src/test/java/software/amazon/aws/clients/swf/flux/tests/CustomSdkConfigurationTest.java
@@ -1,0 +1,122 @@
+package software.amazon.aws.clients.swf.flux.tests;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import software.amazon.aws.clients.swf.flux.FluxCapacitorConfig;
+import software.amazon.aws.clients.swf.flux.step.Attribute;
+import software.amazon.aws.clients.swf.flux.step.StepApply;
+import software.amazon.aws.clients.swf.flux.step.StepAttributes;
+import software.amazon.aws.clients.swf.flux.step.WorkflowStep;
+import software.amazon.aws.clients.swf.flux.wf.Workflow;
+import software.amazon.aws.clients.swf.flux.wf.graph.WorkflowGraph;
+import software.amazon.aws.clients.swf.flux.wf.graph.WorkflowGraphBuilder;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+
+/**
+ * Given an SwfClient object, there's not actually a way to check its configuration.
+ * In order to verify that FluxCapacitorConfig's ClientOverrideConfiguration field
+ * got wired into the SwfClient, we'll configure it with an execution interceptor
+ * and verify that the interceptor got called during the HelloWorld workflow.
+ */
+public class CustomSdkConfigurationTest extends WorkflowTestBase {
+
+    private boolean interceptorCalled;
+
+    ExecutionInterceptor helloInterceptor = new ExecutionInterceptor() {
+        @Override
+        public void afterExecution(Context.AfterExecution context, ExecutionAttributes executionAttributes) {
+            interceptorCalled = true;
+        }
+    };
+
+    @Override
+    protected void updateFluxCapacitorConfig(FluxCapacitorConfig config) {
+        ClientOverrideConfiguration overrideConfig = ClientOverrideConfiguration.builder()
+                .addExecutionInterceptor(helloInterceptor)
+                .build();
+        config.setClientOverrideConfiguration(overrideConfig);
+    }
+
+    @Before
+    public void clearInterceptorCalled() {
+        interceptorCalled = false;
+    }
+
+    @After
+    public void verifyInterceptorCalled() {
+        Assert.assertTrue("If this fails, then FluxCapacitorConfig's ClientOverrideConfiguration was not wired properly.",
+                          interceptorCalled);
+    }
+
+    @Override
+    List<Workflow> getWorkflowsForTest() {
+        return Collections.singletonList(new HelloWorld());
+    }
+
+    /**
+     * Tests that a single-step workflow is executed the expected number of times by worker threads.
+     */
+    @Test
+    public void testBasicWorkflow() throws InterruptedException {
+        String uuid = UUID.randomUUID().toString();
+
+        executeWorkflow(HelloWorld.class, uuid, Collections.emptyMap());
+        waitForWorkflowCompletion(uuid, Duration.ofSeconds(15));
+
+        Assert.assertTrue(StepOne.didExecute(uuid));
+
+        uuid = UUID.randomUUID().toString();
+        executeWorkflow(HelloWorld.class, uuid, Collections.emptyMap());
+        waitForWorkflowCompletion(uuid, Duration.ofSeconds(15));
+
+        Assert.assertTrue(StepOne.didExecute(uuid));
+    }
+
+    /**
+     * Basic workflow with one step.
+     */
+    public static final class HelloWorld implements Workflow {
+        private final WorkflowGraph graph;
+
+        HelloWorld() {
+            WorkflowStep stepOne = new StepOne();
+            WorkflowGraphBuilder builder = new WorkflowGraphBuilder(stepOne, Collections.emptyMap());
+            builder.alwaysClose(stepOne);
+            graph = builder.build();
+        }
+
+        @Override
+        public WorkflowGraph getGraph() {
+            return graph;
+        }
+    }
+
+    /**
+     * Simple step that records which workflow IDs the step is executed for.
+     */
+    public static final class StepOne implements WorkflowStep {
+        private final static Set<String> executedWorkflowIds = Collections.synchronizedSet(new HashSet<>());
+
+        @StepApply
+        public void doThing(@Attribute(StepAttributes.WORKFLOW_ID) String workflowId) {
+            executedWorkflowIds.add(workflowId);
+        }
+
+        static boolean didExecute(String workflowId) {
+            return executedWorkflowIds.contains(workflowId);
+        }
+    }
+}

--- a/flux/src/main/java/software/amazon/aws/clients/swf/flux/FluxCapacitorConfig.java
+++ b/flux/src/main/java/software/amazon/aws/clients/swf/flux/FluxCapacitorConfig.java
@@ -21,6 +21,8 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+
 /**
  * Container for configuration data used by Flux at runtime.
  */
@@ -31,6 +33,7 @@ public class FluxCapacitorConfig {
     private Function<String, String> hostnameTransformerForPollerIdentity = (hostname) -> hostname;
     private String swfEndpoint;
     private String swfDomain;
+    private ClientOverrideConfiguration clientOverrideConfiguration;
     private final Map<String, TaskListConfig> taskListConfigs = new HashMap<>();
 
     public String getAwsRegion() {
@@ -116,6 +119,22 @@ public class FluxCapacitorConfig {
             throw new IllegalArgumentException("swfDomain may not be null.");
         }
         this.swfDomain = swfDomain;
+    }
+
+    public ClientOverrideConfiguration getClientOverrideConfiguration() {
+        return clientOverrideConfiguration;
+    }
+
+    /**
+     * Overrides the default configuration used by the SwfClient created by Flux.
+     *
+     * Note that by default, Flux already overrides the client's default retry policy by disabling it
+     * entirely, and implements its own retry and backoff logic, in order to generate clean metrics.
+     * However, if this override configuration specifies a retry policy, then Flux will not disable
+     * retries, but Flux's SWF API metrics will no longer reflect only durations for single API calls.
+     */
+    public void setClientOverrideConfiguration(ClientOverrideConfiguration clientOverrideConfiguration) {
+        this.clientOverrideConfiguration = clientOverrideConfiguration;
     }
 
     /**


### PR DESCRIPTION
I also added an integration test to verify that the override configuration is actually being used.

https://github.com/awslabs/flux-swf-client/issues/23
