### PR TITLE
Update dependency versions. Bump version to 2.0.4.

### DIFF
--- a/checkstyle-rules.xml
+++ b/checkstyle-rules.xml
@@ -96,7 +96,7 @@
 
         <!-- config_javadoc -->
         <module name="JavadocMethod">
-            <property name="scope" value="public"/>
+            <property name="accessModifiers" value="public"/>
             <property name="allowMissingParamTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
             <property name="allowedAnnotations" value="Override, Test"/>

--- a/flux-common/pom.xml
+++ b/flux-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>software.amazon.aws.clients.swf.flux</groupId>
         <artifactId>flux-swf-client-pom</artifactId>
-        <version>2.0.3</version>
+        <version>2.0.4</version>
     </parent>
     <artifactId>flux-common</artifactId>
     <name>Flux SWF Client Common</name>
@@ -20,6 +20,18 @@
     </licenses>
 
     <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
+            <optional>false</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+            <optional>false</optional>
+        </dependency>
         <dependency>
             <artifactId>swf</artifactId>
             <groupId>software.amazon.awssdk</groupId>

--- a/flux-guice/pom.xml
+++ b/flux-guice/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>software.amazon.aws.clients.swf.flux</groupId>
         <artifactId>flux-swf-client-pom</artifactId>
-        <version>2.0.3</version>
+        <version>2.0.4</version>
     </parent>
     <artifactId>flux-guice</artifactId>
     <name>Flux SWF Client Guice Helper</name>
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.7.0</version> <!-- this was written against newer junit than the rest of the code -->
+            <version>${junit5.version}</version> <!-- this was written against newer junit than the rest of the code -->
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/flux-integration-tests/pom.xml
+++ b/flux-integration-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>software.amazon.aws.clients.swf.flux</groupId>
         <artifactId>flux-swf-client-pom</artifactId>
-        <version>2.0.3</version>
+        <version>2.0.4</version>
     </parent>
     <artifactId>flux-integration-tests</artifactId>
     <name>Flux SWF Client integration tests</name>

--- a/flux-spring/pom.xml
+++ b/flux-spring/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>software.amazon.aws.clients.swf.flux</groupId>
         <artifactId>flux-swf-client-pom</artifactId>
-        <version>2.0.3</version>
+        <version>2.0.4</version>
     </parent>
     <artifactId>flux-spring</artifactId>
     <name>Flux SWF Client Spring Helper</name>

--- a/flux-testutils/pom.xml
+++ b/flux-testutils/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>software.amazon.aws.clients.swf.flux</groupId>
         <artifactId>flux-swf-client-pom</artifactId>
-        <version>2.0.3</version>
+        <version>2.0.4</version>
     </parent>
     <artifactId>flux-testutils</artifactId>
     <name>Flux SWF Client Test Utils</name>

--- a/flux/pom.xml
+++ b/flux/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>software.amazon.aws.clients.swf.flux</groupId>
         <artifactId>flux-swf-client-pom</artifactId>
-        <version>2.0.3</version>
+        <version>2.0.4</version>
     </parent>
     <artifactId>flux</artifactId>
     <name>Flux SWF Client</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>software.amazon.aws.clients.swf.flux</groupId>
     <artifactId>flux-swf-client-pom</artifactId>
-    <version>2.0.3</version>
+    <version>2.0.4</version>
     <packaging>pom</packaging>
     <name>Flux SWF Client POM</name>
     <description>Flux is a client library that simplifies usage of Amazon Simple Workflow Service.</description>
@@ -43,12 +43,23 @@
     </scm>
     <properties>
         <flux.version>${project.version}</flux.version>
-        <awssdk.version>2.15.19</awssdk.version>
-        <jackson.version>2.11.3</jackson.version>
-        <slf4j.version>1.7.30</slf4j.version>
+        <awssdk.version>2.17.9</awssdk.version>
+        <jackson.version>2.12.4</jackson.version>
+        <slf4j.version>1.7.32</slf4j.version>
 
-        <junit.version>4.13.1</junit.version>
-        <easymock.version>4.2</easymock.version>
+        <junit.version>4.13.2</junit.version>
+        <junit5.version>5.7.2</junit5.version>
+        <easymock.version>4.3</easymock.version>
+
+        <mavenplugin.compiler.version>3.8.1</mavenplugin.compiler.version>
+        <mavenplugin.checkstyle.version>3.1.2</mavenplugin.checkstyle.version>
+        <mavenplugin.surefire.version>2.22.2</mavenplugin.surefire.version>
+        <mavenplugin.source.version>3.2.1</mavenplugin.source.version>
+        <mavenplugin.javadoc.version>3.3.0</mavenplugin.javadoc.version>
+        <mavenplugin.gpg.version>3.0.1</mavenplugin.gpg.version>
+        <mavenplugin.nexusstaging.version>1.6.8</mavenplugin.nexusstaging.version>
+
+        <checkstyle.version>8.45</checkstyle.version>
 
         <jre.version>1.8</jre.version>
     </properties>
@@ -57,7 +68,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>${mavenplugin.compiler.version}</version>
                 <configuration>
                     <source>${jre.version}</source>
                     <target>${jre.version}</target>
@@ -68,7 +79,14 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>${mavenplugin.checkstyle.version}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.puppycrawl.tools</groupId>
+                        <artifactId>checkstyle</artifactId>
+                        <version>${checkstyle.version}</version>
+                    </dependency>
+                </dependencies>
                 <executions>
                     <execution>
                         <phase>validate</phase>
@@ -88,7 +106,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>${mavenplugin.surefire.version}</version>
                 <configuration>
                     <parallel>classes</parallel>
                     <threadCount>3</threadCount>
@@ -105,7 +123,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>${mavenplugin.checkstyle.version}</version>
                 <configuration>
                     <configLocation>checkstyle-rules.xml</configLocation>
                     <encoding>UTF-8</encoding>
@@ -135,7 +153,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>3.2.1</version>
+                        <version>${mavenplugin.source.version}</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -148,7 +166,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.2.0</version>
+                        <version>${mavenplugin.javadoc.version}</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>
@@ -161,7 +179,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
+                        <version>${mavenplugin.gpg.version}</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -183,7 +201,7 @@
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.8</version>
+                        <version>${mavenplugin.nexusstaging.version}</version>
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>sonatype-nexus-staging</serverId>


### PR DESCRIPTION
Updates all dependencies, including build tools, to latest stable versions.

flux-common was missing dependency declarations on jackson-core and jackson-databind. It was previously working because these were transitively getting pulled in from the AWS SDK, but the SDK uses their own internally-bundled Jackson now.

I tested the full build+release process (other than publishing to maven-central) to verify that all of the build tool updates worked properly.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
