### PR TITLE
Handle unknown result codes in a better, more user-visible way

### DIFF
--- a/flux/src/main/java/software/amazon/aws/clients/swf/flux/poller/NextStepSelection.java
+++ b/flux/src/main/java/software/amazon/aws/clients/swf/flux/poller/NextStepSelection.java
@@ -1,0 +1,61 @@
+/*
+ *   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package software.amazon.aws.clients.swf.flux.poller;
+
+import software.amazon.aws.clients.swf.flux.step.WorkflowStep;
+
+/**
+ * Utility class for the DecisionTaskPoller to choose what step to execute next (if any).
+ *
+ * Package-private for access in tests.
+ */
+final class NextStepSelection {
+    private static final NextStepSelection CLOSE_WORKFLOW = new NextStepSelection(null, true);
+    private static final NextStepSelection UNKNOWN = new NextStepSelection(null, false);
+
+    private WorkflowStep nextStep;
+    private boolean closeWorkflow;
+
+    public static NextStepSelection closeWorkflow() {
+        return CLOSE_WORKFLOW;
+    }
+
+    public static NextStepSelection unknownResultCode() {
+        return UNKNOWN;
+    }
+
+    public static NextStepSelection scheduleNextStep(WorkflowStep step) {
+        return new NextStepSelection(step, false);
+    }
+
+    private NextStepSelection(WorkflowStep nextStep, boolean closeWorkflow) {
+        this.nextStep = nextStep;
+        this.closeWorkflow = closeWorkflow;
+    }
+
+    public boolean isNextStepUnknown() {
+        return nextStep == null && !closeWorkflow;
+    }
+
+    public boolean workflowShouldClose() {
+        return closeWorkflow;
+    }
+
+    public WorkflowStep getNextStep() {
+        return nextStep;
+    }
+}

--- a/flux/src/test/java/software/amazon/aws/clients/swf/flux/poller/testwf/TestStepReturnsCustomResultCode.java
+++ b/flux/src/test/java/software/amazon/aws/clients/swf/flux/poller/testwf/TestStepReturnsCustomResultCode.java
@@ -1,0 +1,30 @@
+/*
+ *   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package software.amazon.aws.clients.swf.flux.poller.testwf;
+
+import software.amazon.aws.clients.swf.flux.step.StepApply;
+import software.amazon.aws.clients.swf.flux.step.StepResult;
+import software.amazon.aws.clients.swf.flux.step.WorkflowStep;
+
+public class TestStepReturnsCustomResultCode implements WorkflowStep {
+    public static final String RESULT_CODE = "custom-result-code";
+
+    @StepApply
+    public StepResult apply() {
+        return StepResult.complete(RESULT_CODE, "Finished with a custom result code!");
+    }
+}

--- a/flux/src/test/java/software/amazon/aws/clients/swf/flux/poller/testwf/TestWorkflowDoesntHandleCustomResultCode.java
+++ b/flux/src/test/java/software/amazon/aws/clients/swf/flux/poller/testwf/TestWorkflowDoesntHandleCustomResultCode.java
@@ -1,0 +1,39 @@
+/*
+ *   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package software.amazon.aws.clients.swf.flux.poller.testwf;
+
+import software.amazon.aws.clients.swf.flux.wf.Workflow;
+import software.amazon.aws.clients.swf.flux.wf.graph.WorkflowGraph;
+import software.amazon.aws.clients.swf.flux.wf.graph.WorkflowGraphBuilder;
+
+public class TestWorkflowDoesntHandleCustomResultCode implements Workflow {
+
+    private WorkflowGraph graph;
+
+    public TestWorkflowDoesntHandleCustomResultCode() {
+        TestStepReturnsCustomResultCode stepOne = new TestStepReturnsCustomResultCode();
+        WorkflowGraphBuilder builder = new WorkflowGraphBuilder(stepOne);
+        builder.closeOnSuccess(stepOne);
+
+        graph = builder.build();
+    }
+
+    @Override
+    public WorkflowGraph getGraph() {
+        return graph;
+    }
+}


### PR DESCRIPTION
When the decider encounters an unknown result code, it now records a marker with helpful information, and a retry timer.

https://github.com/awslabs/flux-swf-client/issues/15

Here's what it looks like in the SWF Console:

![WIP-unknown-result-code-handling](https://user-images.githubusercontent.com/1361866/128435316-9479a347-52d2-43e5-9ed3-f3702e9ebbf4.png)
