### PR TITLE
Updates to the flux-guice module to support task list bucket count injection.

### DIFF
--- a/flux-guice/src/main/java/software/amazon/aws/clients/swf/flux/guice/ExponentialBackoffBase.java
+++ b/flux-guice/src/main/java/software/amazon/aws/clients/swf/flux/guice/ExponentialBackoffBase.java
@@ -1,3 +1,19 @@
+/*
+ *   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
 package software.amazon.aws.clients.swf.flux.guice;
 
 import java.lang.annotation.ElementType;

--- a/flux-guice/src/main/java/software/amazon/aws/clients/swf/flux/guice/FluxOptionalConfigHolder.java
+++ b/flux-guice/src/main/java/software/amazon/aws/clients/swf/flux/guice/FluxOptionalConfigHolder.java
@@ -1,3 +1,19 @@
+/*
+ *   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
 package software.amazon.aws.clients.swf.flux.guice;
 
 import java.util.Map;
@@ -12,6 +28,7 @@ public class FluxOptionalConfigHolder {
 
     private Double exponentialBackoffBase = null;
     private String swfEndpoint = null;
+    private Map<String, Integer> taskListBucketCounts = null;
     private Map<String, Integer> taskListActivityThreadCounts = null;
     private Map<String, Integer> taskListActivityPollerThreadCounts = null;
     private Map<String, Integer> taskListDeciderThreadCounts = null;
@@ -36,13 +53,21 @@ public class FluxOptionalConfigHolder {
         this.swfEndpoint = swfEndpoint;
     }
 
+    public Map<String, Integer> getTaskListBucketCounts() {
+        return taskListBucketCounts;
+    }
+
+    @Inject(optional = true)
+    public void setTaskListBucketCounts(@TaskListBucketCounts Map<String, Integer> taskListBucketCounts) {
+        this.taskListBucketCounts = taskListBucketCounts;
+    }
+
     public Map<String, Integer> getTaskListActivityThreadCounts() {
         return taskListActivityThreadCounts;
     }
 
     @Inject(optional = true)
-    public void setTaskListActivityThreadCounts(@TaskListActivityThreadCounts
-                                                        Map<String, Integer> taskListActivityThreadCounts) {
+    public void setTaskListActivityThreadCounts(@TaskListActivityThreadCounts Map<String, Integer> taskListActivityThreadCounts) {
         this.taskListActivityThreadCounts = taskListActivityThreadCounts;
     }
 

--- a/flux-guice/src/main/java/software/amazon/aws/clients/swf/flux/guice/SwfEndpoint.java
+++ b/flux-guice/src/main/java/software/amazon/aws/clients/swf/flux/guice/SwfEndpoint.java
@@ -1,3 +1,19 @@
+/*
+ *   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
 package software.amazon.aws.clients.swf.flux.guice;
 
 import java.lang.annotation.ElementType;

--- a/flux-guice/src/main/java/software/amazon/aws/clients/swf/flux/guice/SwfRegion.java
+++ b/flux-guice/src/main/java/software/amazon/aws/clients/swf/flux/guice/SwfRegion.java
@@ -1,3 +1,19 @@
+/*
+ *   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
 package software.amazon.aws.clients.swf.flux.guice;
 
 import java.lang.annotation.ElementType;

--- a/flux-guice/src/main/java/software/amazon/aws/clients/swf/flux/guice/TaskListActivityPollerThreadCounts.java
+++ b/flux-guice/src/main/java/software/amazon/aws/clients/swf/flux/guice/TaskListActivityPollerThreadCounts.java
@@ -1,3 +1,19 @@
+/*
+ *   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
 package software.amazon.aws.clients.swf.flux.guice;
 
 import java.lang.annotation.ElementType;

--- a/flux-guice/src/main/java/software/amazon/aws/clients/swf/flux/guice/TaskListActivityThreadCounts.java
+++ b/flux-guice/src/main/java/software/amazon/aws/clients/swf/flux/guice/TaskListActivityThreadCounts.java
@@ -1,3 +1,19 @@
+/*
+ *   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
 package software.amazon.aws.clients.swf.flux.guice;
 
 import java.lang.annotation.ElementType;

--- a/flux-guice/src/main/java/software/amazon/aws/clients/swf/flux/guice/TaskListBucketCounts.java
+++ b/flux-guice/src/main/java/software/amazon/aws/clients/swf/flux/guice/TaskListBucketCounts.java
@@ -24,11 +24,11 @@ import java.lang.annotation.Target;
 import com.google.inject.BindingAnnotation;
 
 /**
- * Should be attached to a Guice object containing a map of task list names to decider thread counts.
+ * Should be attached to a Guice object containing a map of task list names to bucket counts for those task lists.
  * To be used with FluxModule.
  */
 @Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 @BindingAnnotation
-public @interface TaskListDeciderThreadCounts {
+public @interface TaskListBucketCounts {
 }

--- a/flux-guice/src/main/java/software/amazon/aws/clients/swf/flux/guice/TaskListDeciderPollerThreadCounts.java
+++ b/flux-guice/src/main/java/software/amazon/aws/clients/swf/flux/guice/TaskListDeciderPollerThreadCounts.java
@@ -1,3 +1,19 @@
+/*
+ *   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
 package software.amazon.aws.clients.swf.flux.guice;
 
 import java.lang.annotation.ElementType;

--- a/flux-guice/src/main/java/software/amazon/aws/clients/swf/flux/guice/TaskListPeriodicSubmitterThreadCounts.java
+++ b/flux-guice/src/main/java/software/amazon/aws/clients/swf/flux/guice/TaskListPeriodicSubmitterThreadCounts.java
@@ -1,3 +1,19 @@
+/*
+ *   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
 package software.amazon.aws.clients.swf.flux.guice;
 
 import java.lang.annotation.ElementType;

--- a/flux-guice/src/main/java/software/amazon/aws/clients/swf/flux/guice/WorkflowDomain.java
+++ b/flux-guice/src/main/java/software/amazon/aws/clients/swf/flux/guice/WorkflowDomain.java
@@ -1,3 +1,19 @@
+/*
+ *   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
 package software.amazon.aws.clients.swf.flux.guice;
 
 import java.lang.annotation.ElementType;

--- a/flux-guice/src/test/java/software/amazon/aws/clients/swf/flux/guice/FluxModuleTest.java
+++ b/flux-guice/src/test/java/software/amazon/aws/clients/swf/flux/guice/FluxModuleTest.java
@@ -1,3 +1,19 @@
+/*
+ *   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
 package software.amazon.aws.clients.swf.flux.guice;
 
 import java.util.List;

--- a/flux-guice/src/test/java/software/amazon/aws/clients/swf/flux/guice/workflowone/WorkflowOne.java
+++ b/flux-guice/src/test/java/software/amazon/aws/clients/swf/flux/guice/workflowone/WorkflowOne.java
@@ -1,3 +1,19 @@
+/*
+ *   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
 package software.amazon.aws.clients.swf.flux.guice.workflowone;
 
 import software.amazon.aws.clients.swf.flux.wf.Workflow;

--- a/flux-guice/src/test/java/software/amazon/aws/clients/swf/flux/guice/workflowtwo/WorkflowTwo.java
+++ b/flux-guice/src/test/java/software/amazon/aws/clients/swf/flux/guice/workflowtwo/WorkflowTwo.java
@@ -1,3 +1,19 @@
+/*
+ *   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
 package software.amazon.aws.clients.swf.flux.guice.workflowtwo;
 
 import software.amazon.aws.clients.swf.flux.wf.Workflow;

--- a/flux/src/main/java/software/amazon/aws/clients/swf/flux/TaskListConfig.java
+++ b/flux/src/main/java/software/amazon/aws/clients/swf/flux/TaskListConfig.java
@@ -79,6 +79,10 @@ public class TaskListConfig {
      *
      * The bucket count is applied to activity and decision task workers and pollers, but not periodic submitters.
      *
+     * Keep in mind that while the bucket count can be safely increased for a task list (aside from throttling concerns),
+     * lowering the bucket count can only be done safely if there are no workflows running for this task list, because
+     * Flux only polls for work on task list buckets under this count.
+     *
      * By default, the bucket count is 1.
      */
     public void setBucketCount(int bucketCount) {
@@ -141,7 +145,8 @@ public class TaskListConfig {
             return false;
         }
         TaskListConfig that = (TaskListConfig) other;
-        return activityTaskThreadCount == that.activityTaskThreadCount
+        return bucketCount == that.bucketCount
+               && activityTaskThreadCount == that.activityTaskThreadCount
                && decisionTaskThreadCount == that.decisionTaskThreadCount
                && periodicSubmitterThreadCount == that.periodicSubmitterThreadCount
                && Objects.equals(activityTaskPollerThreadCount, that.activityTaskPollerThreadCount)
@@ -150,7 +155,7 @@ public class TaskListConfig {
 
     @Override
     public int hashCode() {
-        return Objects.hash(activityTaskThreadCount, activityTaskPollerThreadCount, decisionTaskThreadCount,
+        return Objects.hash(bucketCount, activityTaskThreadCount, activityTaskPollerThreadCount, decisionTaskThreadCount,
                             decisionTaskPollerThreadCount, periodicSubmitterThreadCount);
     }
 }


### PR DESCRIPTION
* Added `@TaskListBucketCounts` annotation.
* Removed references to deprecated `FluxCapacitorConfig` methods from `FluxModule.getFluxCapacitorConfig()`.
* Added bucket count initialization to `FluxModule.getFluxCapacitorConfig`.
* Added missing license headers to all flux-guice java files.
* Fixed typo in method name of `FluxModule.initialize()`. This will break anyone who is calling it directly for some reason but the methods on this class are only meant to be called by Guice.

Also in the main flux module:
* Fixed the `TaskListConfig.equals()` and `TaskListConfig.hashCode()` methods to include `bucketCount`.
* Added a note to `TaskListConfig.setBucketCount()` about how to safely lower the bucket count.