### PR TITLE
Preserve partitioned step input attributes if SWF throttles activity creation.

### DIFF
--- a/flux-common/src/main/java/software/amazon/aws/clients/swf/flux/poller/TaskNaming.java
+++ b/flux-common/src/main/java/software/amazon/aws/clients/swf/flux/poller/TaskNaming.java
@@ -24,6 +24,8 @@ import software.amazon.aws.clients.swf.flux.wf.Workflow;
  */
 public final class TaskNaming {
 
+    public static final String PARTITION_METADATA_MARKER_NAME_PREFIX = "_partitionMetadata";
+
     private TaskNaming() {}
 
     public static String workflowName(Workflow workflow) {
@@ -34,20 +36,28 @@ public final class TaskNaming {
         return clazz.getSimpleName();
     }
 
+    public static String stepName(WorkflowStep step) {
+        return stepName(step.getClass());
+    }
+
+    public static String stepName(Class<? extends WorkflowStep> stepClass) {
+        return stepClass.getSimpleName();
+    }
+
     public static String activityName(Workflow workflow, WorkflowStep step) {
-        return String.format("%s.%s", workflowName(workflow), step.getClass().getSimpleName());
+        return activityName(workflowName(workflow), stepName(step));
     }
 
     public static String activityName(Workflow workflow, Class<? extends WorkflowStep> stepClass) {
-        return String.format("%s.%s", workflowName(workflow), stepClass.getSimpleName());
+        return activityName(workflowName(workflow), stepName(stepClass));
     }
 
     public static String activityName(String workflowName, WorkflowStep step) {
-        return String.format("%s.%s", workflowName, step.getClass().getSimpleName());
+        return activityName(workflowName, stepName(step));
     }
 
     public static String activityName(Class<? extends Workflow> workflowClass, Class<? extends WorkflowStep> stepClass) {
-        return activityName(workflowName(workflowClass), stepClass.getSimpleName());
+        return activityName(workflowName(workflowClass), stepName(stepClass));
     }
 
     public static String activityName(String workflowName, String stepName) {
@@ -74,7 +84,6 @@ public final class TaskNaming {
             throw new RuntimeException("Invalid activity name: " + activityName);
         }
         return parts[1];
-
     }
 
     /**
@@ -95,5 +104,12 @@ public final class TaskNaming {
         } else {
             return stepName + "_" + retryAttempt + "_" + partitionId;
         }
+    }
+
+    /**
+     * Given a step name, constructs a partition metadata marker name.
+     */
+    public static String partitionMetadataMarkerName(String stepName) {
+        return String.format("%s.%s", PARTITION_METADATA_MARKER_NAME_PREFIX, stepName);
     }
 }

--- a/flux/src/main/java/software/amazon/aws/clients/swf/flux/poller/PartitionMetadata.java
+++ b/flux/src/main/java/software/amazon/aws/clients/swf/flux/poller/PartitionMetadata.java
@@ -1,0 +1,75 @@
+/*
+ *   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package software.amazon.aws.clients.swf.flux.poller;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import software.amazon.aws.clients.swf.flux.step.PartitionIdGeneratorResult;
+import software.amazon.aws.clients.swf.flux.step.StepAttributes;
+
+/**
+ * Utility class for reading and writing the data in partition metadata markers.
+ *
+ * Package-private for access in tests.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+final class PartitionMetadata {
+
+    @JsonIgnore
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final Set<String> partitionIds;
+    private final Map<String, String> encodedAdditionalAttributes;
+
+    public Set<String> getPartitionIds() {
+        return partitionIds;
+    }
+
+    public Map<String, String> getEncodedAdditionalAttributes() {
+        return encodedAdditionalAttributes;
+    }
+
+    @JsonCreator
+    PartitionMetadata(@JsonProperty("partitionIds") Set<String> partitionIds,
+                      @JsonProperty("encodedAdditionalAttributes") Map<String, String> encodedAdditionalAttributes) {
+        this.partitionIds = Collections.unmodifiableSet(partitionIds);
+        this.encodedAdditionalAttributes = Collections.unmodifiableMap(encodedAdditionalAttributes);
+    }
+
+    public static PartitionMetadata fromPartitionIdGeneratorResult(PartitionIdGeneratorResult result) {
+        return new PartitionMetadata(result.getPartitionIds(),
+                                     StepAttributes.serializeMapValues(result.getAdditionalAttributes()));
+    }
+
+    @JsonIgnore
+    public String toJson() throws JsonProcessingException {
+        return MAPPER.writeValueAsString(this);
+    }
+
+    public static PartitionMetadata fromJson(String json) throws JsonProcessingException {
+        return MAPPER.readValue(json, PartitionMetadata.class);
+    }
+}

--- a/flux/src/test/java/software/amazon/aws/clients/swf/flux/poller/PartitionMetadataTest.java
+++ b/flux/src/test/java/software/amazon/aws/clients/swf/flux/poller/PartitionMetadataTest.java
@@ -1,0 +1,71 @@
+/*
+ *   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package software.amazon.aws.clients.swf.flux.poller;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import software.amazon.aws.clients.swf.flux.step.PartitionIdGeneratorResult;
+import software.amazon.aws.clients.swf.flux.step.StepAttributes;
+
+public class PartitionMetadataTest {
+
+    @Test
+    public void testFromPartitionIdGeneratorResult_NoAttributes() {
+        Set<String> partitionIds = new HashSet<>();
+        partitionIds.add("p1");
+        partitionIds.add("p2");
+        partitionIds.add("p3");
+
+        PartitionIdGeneratorResult genResult = PartitionIdGeneratorResult.create(partitionIds);
+        PartitionMetadata metadata = PartitionMetadata.fromPartitionIdGeneratorResult(genResult);
+
+        Assert.assertEquals(partitionIds, metadata.getPartitionIds());
+
+        Assert.assertEquals(Collections.emptyMap(), metadata.getEncodedAdditionalAttributes());
+    }
+
+    @Test
+    public void testFromPartitionIdGeneratorResult_WithAttributes() {
+        Set<String> partitionIds = new HashSet<>();
+        partitionIds.add("p1");
+        partitionIds.add("p2");
+        partitionIds.add("p3");
+
+        Instant now = Instant.now();
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("number", 42L);
+        attributes.put("string", "some words here");
+        attributes.put("timestamp", now);
+        attributes.put("yes", true);
+
+        PartitionIdGeneratorResult genResult = PartitionIdGeneratorResult.create(partitionIds).withAttributes(attributes);
+        PartitionMetadata metadata = PartitionMetadata.fromPartitionIdGeneratorResult(genResult);
+
+        Assert.assertEquals(partitionIds, metadata.getPartitionIds());
+
+        Map<String, String> encodedAttributes = StepAttributes.serializeMapValues(attributes);
+        Assert.assertEquals(encodedAttributes, metadata.getEncodedAdditionalAttributes());
+    }
+}

--- a/flux/src/test/java/software/amazon/aws/clients/swf/flux/poller/testwf/TestWorkflowWithPartitionedStep.java
+++ b/flux/src/test/java/software/amazon/aws/clients/swf/flux/poller/testwf/TestWorkflowWithPartitionedStep.java
@@ -17,7 +17,7 @@
 package software.amazon.aws.clients.swf.flux.poller.testwf;
 
 import java.util.Arrays;
-import java.util.List;
+import java.util.Collection;
 
 import software.amazon.aws.clients.swf.flux.wf.Workflow;
 import software.amazon.aws.clients.swf.flux.wf.graph.WorkflowGraph;
@@ -31,7 +31,7 @@ public class TestWorkflowWithPartitionedStep implements Workflow {
         this(Arrays.asList("1", "2"));
     }
 
-    public TestWorkflowWithPartitionedStep(List<String> partitionIds) {
+    public TestWorkflowWithPartitionedStep(Collection<String> partitionIds) {
         TestStepOne stepOne = new TestStepOne();
         TestPartitionedStep partitionedStep = new TestPartitionedStep(partitionIds);
         TestStepHasOptionalInputAttribute stepThree = new TestStepHasOptionalInputAttribute();


### PR DESCRIPTION
See issue for the detailed problem description: https://github.com/awslabs/flux-swf-client/issues/33

In short, Flux now records a marker attribute containing the list of partition IDs and any additional attributes returned by the partition id generator. This marker is then used to schedule all of the partitions.

This change _excludes_ handling the case where the marker content is too large and has to be split across multiple markers; I will submit a separate PR to handle that case separately, and I don't intend to publish a new version of the library to maven central until the second change is in.

As I mentioned in the most recent comment on issue 33, I was able to address this bug in a way that Flux will automatically recover any still-running workflow that's in a bad state when this change is deployed.

The integration tests still pass with these changes:

```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Flux SWF Client POM 2.0.5:
[INFO] 
[INFO] Flux SWF Client POM ................................ SUCCESS [  1.164 s]
[INFO] Flux SWF Client Common ............................. SUCCESS [  2.357 s]
[INFO] Flux SWF Client Test Utils ......................... SUCCESS [  1.057 s]
[INFO] Flux SWF Client .................................... SUCCESS [01:17 min]
[INFO] Flux SWF Client Guice Helper ....................... SUCCESS [  1.245 s]
[INFO] Flux SWF Client integration tests .................. SUCCESS [07:20 min]
[INFO] Flux SWF Client Spring Helper ...................... SUCCESS [  0.098 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  08:44 min
[INFO] Finished at: 2021-11-08T14:32:58-08:00
[INFO] ------------------------------------------------------------------------
```


---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
