### PR TITLE
Split partition metadata markers across multiple markers if the partition ID list is too long.

### DIFF
--- a/flux-common/src/main/java/software/amazon/aws/clients/swf/flux/poller/TaskNaming.java
+++ b/flux-common/src/main/java/software/amazon/aws/clients/swf/flux/poller/TaskNaming.java
@@ -65,7 +65,7 @@ public final class TaskNaming {
     }
 
     /**
-     * Given a full activity name (as produced by TaskNaming.activityName()), extracts the workflow name.
+     * Given a full activity name (as produced by {@link #activityName}), extracts the workflow name.
      */
     public static String workflowNameFromActivityName(String activityName) {
         String[] parts = activityName.split("\\.");
@@ -76,7 +76,7 @@ public final class TaskNaming {
     }
 
     /**
-     * Given a full activity name (as produced by TaskNaming.activityName()), extracts the step name.
+     * Given a full activity name (as produced by {@link #activityName}), extracts the step name.
      */
     public static String stepNameFromActivityName(String activityName) {
         String[] parts = activityName.split("\\.");
@@ -107,9 +107,54 @@ public final class TaskNaming {
     }
 
     /**
-     * Given a step name, constructs a partition metadata marker name.
+     * Given a marker name (as produced by {@link #partitionMetadataMarkerName},
+     * determines whether it is a partition metadata marker.
      */
-    public static String partitionMetadataMarkerName(String stepName) {
-        return String.format("%s.%s", PARTITION_METADATA_MARKER_NAME_PREFIX, stepName);
+    public static boolean isPartitionMetadataMarker(String markerName) {
+        return markerName != null && markerName.startsWith(PARTITION_METADATA_MARKER_NAME_PREFIX);
+    }
+
+    /**
+     * Given a step name and information about how many metadata markers there are,
+     * constructs a partition metadata marker name.
+     */
+    public static String partitionMetadataMarkerName(String stepName, long subsetId, long markerCount) {
+        return String.format("%s.%s.%d.%d", PARTITION_METADATA_MARKER_NAME_PREFIX, stepName, subsetId, markerCount);
+    }
+
+    /**
+     * Given a full partition metadata marker name (as produced by {@link #activityName}),
+     * extracts the step name.
+     */
+    public static String extractPartitionMetadataMarkerStepName(String metadataMarkerName) {
+        String[] parts = metadataMarkerName.split("\\.");
+        if (parts.length != 4) {
+            throw new RuntimeException("Invalid metadata marker name: " + metadataMarkerName);
+        }
+        return parts[1];
+    }
+
+    /**
+     * Given a full partition metadata marker name (as produced by {@link #activityName}),
+     * extracts the marker subset id number.
+     */
+    public static Long extractPartitionMetadataMarkerSubsetId(String metadataMarkerName) {
+        String[] parts = metadataMarkerName.split("\\.");
+        if (parts.length != 4) {
+            throw new RuntimeException("Invalid metadata marker name: " + metadataMarkerName);
+        }
+        return Long.parseLong(parts[2]);
+    }
+
+    /**
+     * Given a full partition metadata marker name (as produced by {@link #activityName}),
+     * extracts the marker count.
+     */
+    public static Long extractPartitionMetadataMarkerCount(String metadataMarkerName) {
+        String[] parts = metadataMarkerName.split("\\.");
+        if (parts.length != 4) {
+            throw new RuntimeException("Invalid metadata marker name: " + metadataMarkerName);
+        }
+        return Long.parseLong(parts[3]);
     }
 }

--- a/flux/src/main/java/software/amazon/aws/clients/swf/flux/poller/DecisionTaskPoller.java
+++ b/flux/src/main/java/software/amazon/aws/clients/swf/flux/poller/DecisionTaskPoller.java
@@ -516,14 +516,18 @@ public class DecisionTaskPoller implements Runnable {
                                                                          workflowId, metricsFactory);
             PartitionMetadata metadata = PartitionMetadata.fromPartitionIdGeneratorResult(result);
 
-            RecordMarkerDecisionAttributes markerAttrs = RecordMarkerDecisionAttributes.builder()
-                    .markerName(TaskNaming.partitionMetadataMarkerName(nextStepName))
-                    .details(metadata.toJson())
-                    .build();
-            Decision marker = Decision.builder().decisionType(DecisionType.RECORD_MARKER)
-                    .recordMarkerDecisionAttributes(markerAttrs)
-                    .build();
-            decisions.add(marker);
+            List<String> markerDetailsList = metadata.toMarkerDetailsList();
+            for (int i = 0; i < markerDetailsList.size(); i++) {
+                String markerDetails = markerDetailsList.get(i);
+                RecordMarkerDecisionAttributes markerAttrs = RecordMarkerDecisionAttributes.builder()
+                        .markerName(TaskNaming.partitionMetadataMarkerName(nextStepName, i, markerDetailsList.size()))
+                        .details(markerDetails)
+                        .build();
+                Decision marker = Decision.builder().decisionType(DecisionType.RECORD_MARKER)
+                        .recordMarkerDecisionAttributes(markerAttrs)
+                        .build();
+                decisions.add(marker);
+            }
 
             SignalExternalWorkflowExecutionDecisionAttributes hackAttrs = buildHackSignalDecisionAttrs(state);
             Decision hackSignal = Decision.builder().decisionType(DecisionType.SIGNAL_EXTERNAL_WORKFLOW_EXECUTION)

--- a/flux/src/main/java/software/amazon/aws/clients/swf/flux/poller/PartitionMetadata.java
+++ b/flux/src/main/java/software/amazon/aws/clients/swf/flux/poller/PartitionMetadata.java
@@ -17,8 +17,13 @@
 package software.amazon.aws.clients.swf.flux.poller;
 
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -26,6 +31,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import software.amazon.aws.clients.swf.flux.step.PartitionIdGeneratorResult;
 import software.amazon.aws.clients.swf.flux.step.StepAttributes;
@@ -41,6 +48,9 @@ final class PartitionMetadata {
     @JsonIgnore
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
+    @JsonIgnore
+    private static final Logger log = LoggerFactory.getLogger(PartitionMetadata.class);
+
     private final Set<String> partitionIds;
     private final Map<String, String> encodedAdditionalAttributes;
 
@@ -55,7 +65,8 @@ final class PartitionMetadata {
     @JsonCreator
     PartitionMetadata(@JsonProperty("partitionIds") Set<String> partitionIds,
                       @JsonProperty("encodedAdditionalAttributes") Map<String, String> encodedAdditionalAttributes) {
-        this.partitionIds = Collections.unmodifiableSet(partitionIds);
+        // Strictly speaking this doesn't need to be sorted but it makes testing a lot easier.
+        this.partitionIds = Collections.unmodifiableSortedSet(new TreeSet<>(partitionIds));
         this.encodedAdditionalAttributes = Collections.unmodifiableMap(encodedAdditionalAttributes);
     }
 
@@ -64,12 +75,108 @@ final class PartitionMetadata {
                                      StepAttributes.serializeMapValues(result.getAdditionalAttributes()));
     }
 
+    /**
+     * Marker details can't exceed 32768 bytes, so we need to return a list of json-formatted strings with the partition id list
+     * split between them.
+     *
+     * Only the first entry will contain the encodedAdditionalAttributes list.
+     */
     @JsonIgnore
-    public String toJson() throws JsonProcessingException {
-        return MAPPER.writeValueAsString(this);
+    public List<String> toMarkerDetailsList() throws JsonProcessingException {
+        // Most of the time, the entire thing will fit in one marker, so we'll generate that and return it if it's short enough.
+        // We do this because calculating the actual size one partition ID at a time is relatively expensive.
+
+        // We'll leave ourselves a little wiggle room for our attribute names, and to simplify the logic below.
+        // This way we can overrun our length limit by one partition id without it being a problem.
+        // The actual max enforced by SWF is 32768, and partition IDs can't be longer than 250 characters anyway, since
+        // the activity ID would get too long.
+        int maxLength = 32000;
+
+        String fullJson = MAPPER.writeValueAsString(this);
+        if (fullJson.length() <= maxLength) {
+            return Collections.singletonList(fullJson);
+        }
+
+        // The base json looks like this, which is 52 characters long:
+        // {"partitionIds":[],"encodedAdditionalAttributes":{}}
+        // We're going to account for the empty encodedAdditionalAttributes map below,
+        // so we'll subtract two from the base length.
+        int baseJsonSize = 50;
+
+        Map<String, String> attributes = encodedAdditionalAttributes;
+        int attributeMapSize = MAPPER.writeValueAsString(attributes).length();
+
+        List<String> subsets = new LinkedList<>();
+
+        // We'll use a TreeSet here even though it doesn't really need to be sorted in the output just so testing is easier.
+        Set<String> partitionIdSubset = new TreeSet<>();
+        int partitionIdSubsetSize = 0;
+        for (String partitionId : partitionIds) {
+
+            // This serialization includes the quotes around the partition IDs, and we need to account for a comma after each.
+            // We can't just do a naive "length plus three"; there might be escaped characters in the serialized identifier.
+            // This technically means we're counting one extra comma than we will actually use but this shouldn't cause
+            // any extra markers to be generated since it only matters for the last partition ID, and we allow exceeding maxLength
+            // for the last partition ID in each subset.
+            String serialized = MAPPER.writeValueAsString(partitionId);
+            partitionIdSubsetSize += serialized.length() + 1;
+
+            // We add the partition ID here, not the serialized version, since we'll properly re-serialize the partition metadata
+            // as a whole once we have enough partition IDs.
+            partitionIdSubset.add(partitionId);
+
+            if (partitionIdSubsetSize + attributeMapSize + baseJsonSize >= maxLength) {
+                PartitionMetadata subset = new PartitionMetadata(partitionIdSubset, attributes);
+                subsets.add(MAPPER.writeValueAsString(subset));
+
+                partitionIdSubset.clear();
+                partitionIdSubsetSize = 0;
+
+                // This ensures only the first metadata marker contains the attributes.
+                attributes = Collections.emptyMap();
+
+                // Even though the subsequent pages have no attributes, they still have
+                // the empty attribute map entry, which is two characters.
+                attributeMapSize = 2;
+
+            }
+        }
+
+        if (partitionIdSubset.size() > 0) {
+            PartitionMetadata subset = new PartitionMetadata(partitionIdSubset, attributes);
+            subsets.add(MAPPER.writeValueAsString(subset));
+        }
+
+        return subsets;
     }
 
-    public static PartitionMetadata fromJson(String json) throws JsonProcessingException {
-        return MAPPER.readValue(json, PartitionMetadata.class);
+    /**
+     * Since toMarkerDetailsList() may split the marker into multiple json blobs, we need to reconstruct the original metadata from
+     * a list of json blobs, combining their partition id lists.
+     *
+     * If any of the markers contain invalid JSON, the marker is skipped. If the list is empty or contains only invalid markers,
+     * then this returns null.
+     */
+    public static PartitionMetadata fromMarkerDetailsList(List<String> markerDetailsList) throws JsonProcessingException {
+        Set<String> partitionIds = new HashSet<>();
+        Map<String, String> encodedAdditionalAttributes = new HashMap<>();
+        boolean atLeastOneValidMetadataMarker = false;
+
+        for (String markerDetails : markerDetailsList) {
+            try {
+                PartitionMetadata metadata = MAPPER.readValue(markerDetails, PartitionMetadata.class);
+                partitionIds.addAll(metadata.getPartitionIds());
+                encodedAdditionalAttributes.putAll(metadata.getEncodedAdditionalAttributes());
+                atLeastOneValidMetadataMarker = true;
+            } catch (JsonProcessingException e) {
+                log.warn("Failed to deserialize partition metadata marker details, skipping.", e);
+            }
+        }
+
+        if (!atLeastOneValidMetadataMarker) {
+            return null;
+        }
+
+        return new PartitionMetadata(partitionIds, encodedAdditionalAttributes);
     }
 }

--- a/flux/src/test/java/software/amazon/aws/clients/swf/flux/IdUtils.java
+++ b/flux/src/test/java/software/amazon/aws/clients/swf/flux/IdUtils.java
@@ -1,0 +1,17 @@
+package software.amazon.aws.clients.swf.flux;
+
+import java.util.Random;
+
+public final class IdUtils {
+
+    private static final Random rand = new Random();
+    private static final String ID_CHARS = "0123456789abcdefghijklmnopqrstuvwxyz";
+
+    public static String randomId(int idLength) {
+        StringBuilder sb = new StringBuilder(idLength);
+        for (int i = 0; i < idLength; i++) {
+            sb.append(ID_CHARS.charAt(rand.nextInt(ID_CHARS.length())));
+        }
+        return sb.toString();
+    }
+}

--- a/flux/src/test/java/software/amazon/aws/clients/swf/flux/poller/PartitionMetadataTest.java
+++ b/flux/src/test/java/software/amazon/aws/clients/swf/flux/poller/PartitionMetadataTest.java
@@ -17,15 +17,22 @@
 package software.amazon.aws.clients.swf.flux.poller;
 
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
 
 import org.junit.Assert;
 import org.junit.Test;
 
+import software.amazon.aws.clients.swf.flux.IdUtils;
 import software.amazon.aws.clients.swf.flux.step.PartitionIdGeneratorResult;
 import software.amazon.aws.clients.swf.flux.step.StepAttributes;
 
@@ -33,7 +40,7 @@ public class PartitionMetadataTest {
 
     @Test
     public void testFromPartitionIdGeneratorResult_NoAttributes() {
-        Set<String> partitionIds = new HashSet<>();
+        Set<String> partitionIds = new TreeSet<>();
         partitionIds.add("p1");
         partitionIds.add("p2");
         partitionIds.add("p3");
@@ -48,7 +55,7 @@ public class PartitionMetadataTest {
 
     @Test
     public void testFromPartitionIdGeneratorResult_WithAttributes() {
-        Set<String> partitionIds = new HashSet<>();
+        Set<String> partitionIds = new TreeSet<>();
         partitionIds.add("p1");
         partitionIds.add("p2");
         partitionIds.add("p3");
@@ -66,6 +73,277 @@ public class PartitionMetadataTest {
         Assert.assertEquals(partitionIds, metadata.getPartitionIds());
 
         Map<String, String> encodedAttributes = StepAttributes.serializeMapValues(attributes);
+        Assert.assertEquals(encodedAttributes, metadata.getEncodedAdditionalAttributes());
+    }
+
+    @Test
+    public void testToMarkerDetailsList_FitsInOneMarker() throws JsonProcessingException {
+        Set<String> partitionIds = new TreeSet<>();
+        partitionIds.add("p1");
+        partitionIds.add("p2");
+        partitionIds.add("p3");
+
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("number", 42L);
+        attributes.put("string", "some words here");
+        attributes.put("yes", true);
+
+        PartitionIdGeneratorResult genResult = PartitionIdGeneratorResult.create(partitionIds).withAttributes(attributes);
+        PartitionMetadata metadata = PartitionMetadata.fromPartitionIdGeneratorResult(genResult);
+
+        String expectedJson = "{\"partitionIds\":[\"p1\",\"p2\",\"p3\"],"
+                              + "\"encodedAdditionalAttributes\":"
+                              +   "{\"number\":\"42\",\"string\":\"\\\"some words here\\\"\",\"yes\":\"true\"}"
+                              + "}";
+
+        List<String> detailsList = metadata.toMarkerDetailsList();
+        Assert.assertEquals(1, detailsList.size());
+        Assert.assertEquals(expectedJson, detailsList.get(0));
+    }
+
+    @Test
+    public void testToMarkerDetailsList_MultipleMarkers() throws JsonProcessingException {
+        Set<String> partitionIds = new TreeSet<>();
+        for (int i = 0; i < 1000; i++) {
+            partitionIds.add(IdUtils.randomId(100));
+        }
+
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("number", 42L);
+        attributes.put("string", "some words here");
+        attributes.put("yes", true);
+
+        PartitionIdGeneratorResult genResult = PartitionIdGeneratorResult.create(partitionIds).withAttributes(attributes);
+        PartitionMetadata metadata = PartitionMetadata.fromPartitionIdGeneratorResult(genResult);
+
+        // The expectedFirstJson string is 109 characters long excluding the partition ID array.
+        // Each partition ID has double-quotes around it and the IDs are comma-separated.
+        // So a list of N 100-character partition IDs will use up N*100 + N*2 + (N-1) characters, or (N*103)-1.
+        // To determine how many partition IDs are on the first page, we need to solve this equation:
+        // 32000 - 109 = (N * 103) - 1
+        // which is 31892 = (N*103)
+        // so N = 31892 / 103 = 309.6 and since we add partition IDs until we run _over the max length, we round up.
+        // The first marker should have 310 partition IDs.
+        //
+        // After that, each marker should have the next N = 32001/103 = 310.6  or 311 partition IDs until the last page.
+        // The last page will have 1000 - 310 - 311 - 311 = 68 partition IDs.
+
+        Iterator<String> iter = partitionIds.iterator();
+        Set<String> page1 = new TreeSet<>();
+        for (int i = 0; i < 310; i++) {
+            page1.add(iter.next());
+        }
+        Set<String> page2 = new TreeSet<>();
+        for (int i = 0; i < 311; i++) {
+            page2.add(iter.next());
+        }
+        Set<String> page3 = new TreeSet<>();
+        for (int i = 0; i < 311; i++) {
+            page3.add(iter.next());
+        }
+        Set<String> page4 = new TreeSet<>();
+        while (iter.hasNext()) {
+            page4.add(iter.next());
+        }
+        Assert.assertEquals(68, page4.size());
+
+        String expectedJson1 = "{\"partitionIds\":[\""
+                               + String.join("\",\"", page1)
+                               + "\"],"
+                               + "\"encodedAdditionalAttributes\":"
+                               + "{\"number\":\"42\",\"string\":\"\\\"some words here\\\"\",\"yes\":\"true\"}}";
+        Assert.assertTrue(32768 > expectedJson1.length());
+
+        String expectedJson2 = "{\"partitionIds\":[\""
+                               + String.join("\",\"", page2)
+                               + "\"],\"encodedAdditionalAttributes\":{}}";
+        Assert.assertTrue(32768 > expectedJson2.length());
+
+        String expectedJson3 = "{\"partitionIds\":[\""
+                               + String.join("\",\"", page3)
+                               + "\"],\"encodedAdditionalAttributes\":{}}";
+        Assert.assertTrue(32768 > expectedJson3.length());
+
+        String expectedJson4 = "{\"partitionIds\":[\""
+                               + String.join("\",\"", page4)
+                               + "\"],\"encodedAdditionalAttributes\":{}}";
+        Assert.assertTrue(32768 > expectedJson4.length());
+
+        List<String> detailsList = metadata.toMarkerDetailsList();
+        Assert.assertEquals(4, detailsList.size());
+        Assert.assertEquals(expectedJson1, detailsList.get(0));
+        Assert.assertEquals(expectedJson2, detailsList.get(1));
+        Assert.assertEquals(expectedJson3, detailsList.get(2));
+        Assert.assertEquals(expectedJson4, detailsList.get(3));
+    }
+
+    @Test
+    public void testFromMarkerDetailsList_OneMarker() throws JsonProcessingException {
+        String inputJson = "{\"partitionIds\":[\"p1\",\"p2\",\"p3\"],"
+                              + "\"encodedAdditionalAttributes\":"
+                              +   "{\"number\":\"42\",\"string\":\"\\\"some words here\\\"\",\"yes\":\"true\"}"
+                              + "}";
+        PartitionMetadata metadata = PartitionMetadata.fromMarkerDetailsList(Collections.singletonList(inputJson));
+
+        Set<String> partitionIds = new HashSet<>();
+        partitionIds.add("p1");
+        partitionIds.add("p2");
+        partitionIds.add("p3");
+
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("number", 42L);
+        attributes.put("string", "some words here");
+        attributes.put("yes", true);
+
+        Map<String, String> encodedAttributes = StepAttributes.serializeMapValues(attributes);
+
+        Assert.assertEquals(partitionIds, metadata.getPartitionIds());
+        Assert.assertEquals(encodedAttributes, metadata.getEncodedAdditionalAttributes());
+    }
+
+    @Test
+    public void testFromMarkerDetailsList_InvalidMarker() throws JsonProcessingException {
+        String inputJson = "this is not valid json {";
+        Assert.assertNull(PartitionMetadata.fromMarkerDetailsList(Collections.singletonList(inputJson)));
+    }
+
+    @Test
+    public void testFromMarkerDetailsList_MultipleMarkers() throws JsonProcessingException {
+        // We'll use a TreeSet so that the set is consistently sorted when we iterate through it.
+        Set<String> partitionIds = new TreeSet<>();
+        for (int i = 0; i < 1000; i++) {
+            partitionIds.add(IdUtils.randomId(100));
+        }
+
+        // The expectedFirstJson string is 109 characters long excluding the partition ID array.
+        // Each partition ID has double-quotes around it and the IDs are comma-separated.
+        // So a list of N 100-character partition IDs will use up N*100 + N*2 + (N-1) characters, or (N*103)-1.
+        // To determine how many partition IDs are on the first page, we need to solve this equation:
+        // 32000 - 109 = (N * 103) - 1
+        // which is 31892 = (N*103)
+        // so N = 31892 / 103 = 309.6 and since we add partition IDs until we run _over the max length, we round up.
+        // The first marker should have 310 partition IDs.
+        //
+        // After that, each marker should have the next N = 32001/103 = 310.6  or 311 partition IDs until the last page.
+        // The last page will have 1000 - 310 - 311 - 311 = 68 partition IDs.
+
+        Iterator<String> iter = partitionIds.iterator();
+        Set<String> page1 = new TreeSet<>();
+        for (int i = 0; i < 310; i++) {
+            page1.add(iter.next());
+        }
+        Set<String> page2 = new TreeSet<>();
+        for (int i = 0; i < 311; i++) {
+            page2.add(iter.next());
+        }
+        Set<String> page3 = new TreeSet<>();
+        for (int i = 0; i < 311; i++) {
+            page3.add(iter.next());
+        }
+        Set<String> page4 = new TreeSet<>();
+        while (iter.hasNext()) {
+            page4.add(iter.next());
+        }
+        Assert.assertEquals(68, page4.size());
+
+        String inputJson1 = "{\"partitionIds\":[\""
+                            + String.join("\",\"", page1)
+                            + "\"],"
+                            + "\"encodedAdditionalAttributes\":"
+                            + "{\"number\":\"42\",\"string\":\"\\\"some words here\\\"\",\"yes\":\"true\"}}";
+
+        String inputJson2 = "{\"partitionIds\":[\""
+                            + String.join("\",\"", page2)
+                            + "\"],\"encodedAdditionalAttributes\":{}}";
+
+        String inputJson3 = "{\"partitionIds\":[\""
+                            + String.join("\",\"", page3)
+                            + "\"],\"encodedAdditionalAttributes\":{}}";
+
+        String inputJson4 = "{\"partitionIds\":[\""
+                            + String.join("\",\"", page4)
+                            + "\"],\"encodedAdditionalAttributes\":{}}";
+
+        PartitionMetadata metadata = PartitionMetadata.fromMarkerDetailsList(Arrays.asList(inputJson1, inputJson2, inputJson3, inputJson4));
+
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("number", 42L);
+        attributes.put("string", "some words here");
+        attributes.put("yes", true);
+        Map<String, String> encodedAttributes = StepAttributes.serializeMapValues(attributes);
+
+        Assert.assertEquals(partitionIds, metadata.getPartitionIds());
+        Assert.assertEquals(encodedAttributes, metadata.getEncodedAdditionalAttributes());
+    }
+
+    @Test
+    public void testFromMarkerDetailsList_IgnoresInvalidExtraMarker() throws JsonProcessingException {
+        // We'll use a TreeSet so that the set is consistently sorted when we iterate through it.
+        Set<String> partitionIds = new TreeSet<>();
+        for (int i = 0; i < 1000; i++) {
+            partitionIds.add(IdUtils.randomId(100));
+        }
+
+        // The expectedFirstJson string is 109 characters long excluding the partition ID array.
+        // Each partition ID has double-quotes around it and the IDs are comma-separated.
+        // So a list of N 100-character partition IDs will use up N*100 + N*2 + (N-1) characters, or (N*103)-1.
+        // To determine how many partition IDs are on the first page, we need to solve this equation:
+        // 32000 - 109 = (N * 103) - 1
+        // which is 31892 = (N*103)
+        // so N = 31892 / 103 = 309.6 and since we add partition IDs until we run _over the max length, we round up.
+        // The first marker should have 310 partition IDs.
+        //
+        // After that, each marker should have the next N = 32001/103 = 310.6  or 311 partition IDs until the last page.
+        // The last page will have 1000 - 310 - 311 - 311 = 68 partition IDs.
+
+        Iterator<String> iter = partitionIds.iterator();
+        Set<String> page1 = new TreeSet<>();
+        for (int i = 0; i < 310; i++) {
+            page1.add(iter.next());
+        }
+        Set<String> page2 = new TreeSet<>();
+        for (int i = 0; i < 311; i++) {
+            page2.add(iter.next());
+        }
+        Set<String> page3 = new TreeSet<>();
+        for (int i = 0; i < 311; i++) {
+            page3.add(iter.next());
+        }
+        Set<String> page4 = new TreeSet<>();
+        while (iter.hasNext()) {
+            page4.add(iter.next());
+        }
+        Assert.assertEquals(68, page4.size());
+
+        String inputJson1 = "{\"partitionIds\":[\""
+                            + String.join("\",\"", page1)
+                            + "\"],"
+                            + "\"encodedAdditionalAttributes\":"
+                            + "{\"number\":\"42\",\"string\":\"\\\"some words here\\\"\",\"yes\":\"true\"}}";
+
+        String inputJson2 = "{\"partitionIds\":[\""
+                            + String.join("\",\"", page2)
+                            + "\"],\"encodedAdditionalAttributes\":{}}";
+
+        String inputJson3 = "{\"partitionIds\":[\""
+                            + String.join("\",\"", page3)
+                            + "\"],\"encodedAdditionalAttributes\":{}}";
+
+        String inputJson4 = "{\"partitionIds\":[\""
+                            + String.join("\",\"", page4)
+                            + "\"],\"encodedAdditionalAttributes\":{}}";
+
+        String invalidJson = "this is not valid json {";
+
+        PartitionMetadata metadata = PartitionMetadata.fromMarkerDetailsList(Arrays.asList(inputJson1, inputJson2, invalidJson, inputJson3, inputJson4));
+
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("number", 42L);
+        attributes.put("string", "some words here");
+        attributes.put("yes", true);
+        Map<String, String> encodedAttributes = StepAttributes.serializeMapValues(attributes);
+
+        Assert.assertEquals(partitionIds, metadata.getPartitionIds());
         Assert.assertEquals(encodedAttributes, metadata.getEncodedAdditionalAttributes());
     }
 }

--- a/flux/src/test/java/software/amazon/aws/clients/swf/flux/poller/WorkflowHistoryBuilder.java
+++ b/flux/src/test/java/software/amazon/aws/clients/swf/flux/poller/WorkflowHistoryBuilder.java
@@ -611,13 +611,19 @@ public class WorkflowHistoryBuilder {
         return recordSignalEvent(signal);
     }
 
-    public HistoryEvent recordPartitionMetadataMarker(Instant eventTime, String stepName,
-                                                      PartitionIdGeneratorResult partitionIdGeneratorResult)
+    public List<HistoryEvent> recordPartitionMetadataMarkers(Instant eventTime, String stepName,
+                                                             PartitionIdGeneratorResult partitionIdGeneratorResult)
             throws JsonProcessingException {
         PartitionMetadata metadata = PartitionMetadata.fromPartitionIdGeneratorResult(partitionIdGeneratorResult);
 
-        return recordMarker(eventTime, TaskNaming.partitionMetadataMarkerName(stepName),
-                            metadata.toJson());
+        List<String> markerDetailsList = metadata.toMarkerDetailsList();
+
+        List<HistoryEvent> markers = new ArrayList<>();
+        for (int i = 0; i < markerDetailsList.size(); i++) {
+            markers.add(recordMarker(eventTime, TaskNaming.partitionMetadataMarkerName(stepName, i, markerDetailsList.size()),
+                                    markerDetailsList.get(i)));
+        }
+        return markers;
     }
 
     public HistoryEvent recordMarker(Instant eventTime, String name, String details) {


### PR DESCRIPTION
This is the rest of the fix for https://github.com/awslabs/flux-swf-client/issues/33

If the size of the serialized metadata marker exceeds 32000 bytes, the metadata will now be split across multiple markers. The first marker contains the encoded additional attributes map as well as the first subset of partition IDs; the remaining markers each contain a subset of the remaining partition IDs.

On reassembly, the markers are recombined into a single PartitionMetadata object (if all of the markers are present).

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
