### PR TITLE
Name the various thread pools with relevant names.

### DIFF
--- a/flux-common/src/main/java/software/amazon/aws/clients/swf/flux/FluxCapacitor.java
+++ b/flux-common/src/main/java/software/amazon/aws/clients/swf/flux/FluxCapacitor.java
@@ -54,9 +54,11 @@ public interface FluxCapacitor {
                                                      String workflowDomain);
 
     /**
-     * Shuts down this FluxCapacitor object's worker threads.
+     * Shuts down this FluxCapacitor object's worker thread pools. Running threads are not interrupted.
      * Once you call this method, this FluxCapacitor object should not be used anymore,
      * a new one should be created with FluxCapacitorFactory.create instead.
+     *
+     * FluxCapacitor will likely take about 60 seconds to shut down, since that's the long-polling duration.
      *
      * This method obeys the ExecutorService.shutdown() contract.
      */

--- a/flux-integration-tests/pom.xml
+++ b/flux-integration-tests/pom.xml
@@ -36,7 +36,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <artifactId>slf4j-nop</artifactId>
+            <artifactId>slf4j-simple</artifactId>
             <groupId>org.slf4j</groupId>
             <version>${slf4j.version}</version>
             <scope>test</scope>

--- a/flux-integration-tests/src/test/resources/simplelogger.properties
+++ b/flux-integration-tests/src/test/resources/simplelogger.properties
@@ -1,0 +1,4 @@
+org.slf4j.simpleLogger.showDateTime=true
+org.slf4j.simpleLogger.dateTimeFormat=[yyyy-MM-dd HH:mm:ss:SSS]
+org.slf4j.simpleLogger.showLogName=true
+org.slf4j.simpleLogger.showShortLogName=true

--- a/flux/src/main/java/software/amazon/aws/clients/swf/flux/poller/BlockOnSubmissionThreadPoolExecutor.java
+++ b/flux/src/main/java/software/amazon/aws/clients/swf/flux/poller/BlockOnSubmissionThreadPoolExecutor.java
@@ -40,9 +40,9 @@ public class BlockOnSubmissionThreadPoolExecutor extends ThreadPoolExecutor {
     /**
      * Creates a fixed-size thread pool.
      */
-    public BlockOnSubmissionThreadPoolExecutor(int fixedPoolSize) {
+    public BlockOnSubmissionThreadPoolExecutor(int fixedPoolSize, final String poolName) {
         super(fixedPoolSize, fixedPoolSize, 0L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>(fixedPoolSize),
-              ThreadUtils.createStackTraceSuppressingThreadFactory());
+              ThreadUtils.createStackTraceSuppressingThreadFactory(poolName));
         submissionSemaphore = new Semaphore(fixedPoolSize);
     }
 

--- a/flux/src/test/java/software/amazon/aws/clients/swf/flux/poller/ActivityTaskPollerTest.java
+++ b/flux/src/test/java/software/amazon/aws/clients/swf/flux/poller/ActivityTaskPollerTest.java
@@ -185,7 +185,7 @@ public class ActivityTaskPollerTest {
             }
         };
 
-        executor = new BlockOnSubmissionThreadPoolExecutor(1);
+        executor = new BlockOnSubmissionThreadPoolExecutor(1, "executor");
         poller = new ActivityTaskPoller(metricsFactory, swf, DOMAIN, Workflow.DEFAULT_TASK_LIST_NAME,
                                         IDENTITY, workflows, steps, executor);
     }

--- a/flux/src/test/java/software/amazon/aws/clients/swf/flux/poller/BlockOnSubmissionThreadPoolExecutorTest.java
+++ b/flux/src/test/java/software/amazon/aws/clients/swf/flux/poller/BlockOnSubmissionThreadPoolExecutorTest.java
@@ -31,7 +31,7 @@ public class BlockOnSubmissionThreadPoolExecutorTest {
 
     @Before
     public void setup() {
-        executor = new BlockOnSubmissionThreadPoolExecutor(1);
+        executor = new BlockOnSubmissionThreadPoolExecutor(1, "executor");
     }
 
     @Test

--- a/flux/src/test/java/software/amazon/aws/clients/swf/flux/poller/DecisionTaskPollerTest.java
+++ b/flux/src/test/java/software/amazon/aws/clients/swf/flux/poller/DecisionTaskPollerTest.java
@@ -181,7 +181,7 @@ public class DecisionTaskPollerTest {
             }
         };
 
-        executor = new BlockOnSubmissionThreadPoolExecutor(1);
+        executor = new BlockOnSubmissionThreadPoolExecutor(1, "executor");
         poller = new DecisionTaskPoller(metricsFactory, swf, DOMAIN, Workflow.DEFAULT_TASK_LIST_NAME, IDENTITY,
                                         FluxCapacitorImpl.DEFAULT_EXPONENTIAL_BACKOFF_BASE, workflows, activities, executor);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${mavenplugin.surefire.version}</version>
                 <configuration>
+                    <argLine>-Duser.timezone=UTC</argLine>
                     <parallel>classes</parallel>
                     <threadCount>3</threadCount>
                     <includes>


### PR DESCRIPTION
Name the various thread pools with relevant names.

Instead of threads named e.g. `pool-1-thread-1`, after this change the threads will be named after their purpose (decider, worker, poller, etc) and their task list name, e.g. `decider-default-1-thread-1`.

Fixed test configuration:
* Always run tests using the UTC time zone.
* Enable logging to the console during integration tests (using slf4j-simple).

https://github.com/awslabs/flux-swf-client/issues/38

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
