### PR TITLE
GPG key management scripts. Build pulls key ID from secrets manager instead of hardcoding.

### DIFF
--- a/buildspec/build-and-publish.yml
+++ b/buildspec/build-and-publish.yml
@@ -2,6 +2,7 @@
 version: 0.2
 env:
   secrets-manager:
+    GPG_KEY_ID: "gpg-signing-key-id"
     GPG_PASSPHRASE: "gpg-signing-key-passphrase"
     GPG_PRIVATE_KEY: "gpg-signing-key-private-key"
     MAVEN_CENTRAL_USERNAME: "MavenCentral:username"

--- a/buildspec/build-and-stage.yml
+++ b/buildspec/build-and-stage.yml
@@ -2,6 +2,7 @@
 version: 0.2
 env:
   secrets-manager:
+    GPG_KEY_ID: "gpg-signing-key-id"
     GPG_PASSPHRASE: "gpg-signing-key-passphrase"
     GPG_PRIVATE_KEY: "gpg-signing-key-private-key"
     MAVEN_CENTRAL_USERNAME: "MavenCentral:username"

--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
                             </execution>
                         </executions>
                         <configuration>
-                            <keyname>A9C2E0DFFED2658D75A64D7A7C5DC8336806E60E</keyname>
+                            <keyname>${env.GPG_KEY_ID}</keyname>
                             <passphrase>${env.GPG_PASSPHRASE}</passphrase>
                             <gpgArguments>
                                 <arg>--batch</arg>

--- a/scripts/generate-flux-gpg-key.sh
+++ b/scripts/generate-flux-gpg-key.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+set +e
+
+if ! command -v aws &> /dev/null
+then
+  echo "Please install the AWS CLI."
+  exit 1
+fi
+
+if ! command -v pwgen &> /dev/null
+then
+  echo "Please install pwgen."
+  exit 2
+fi
+
+if ! command -v gpg &> /dev/null
+then
+  echo "Please install gpg."
+  exit 3
+fi
+
+# you'll also need the AWS CLI to be configured with credentials for our AWS account.
+
+AWS_DEFAULT_REGION=us-west-2
+FLUX_REALNAME="Flux SWF Client"
+FLUX_EMAIL="aws-flux-swf-client-owners@amazon.com"
+
+TEMPDIR=$(mktemp -d)
+echo "Working in ${TEMPDIR}..."
+
+echo "Generating passphrase..."
+FLUX_GPG_PASSPHRASE=$(pwgen -s 16 1)
+
+echo "Generating key..."
+gpg --homedir $TEMPDIR --batch --gen-key <<FOO
+    Key-Type: RSA
+    Key-Length: 4096
+    Name-Real: $FLUX_REALNAME
+    Name-Email: $FLUX_EMAIL
+    Expire-Date: 1y
+    Passphrase: $FLUX_GPG_PASSPHRASE
+    %commit
+    %echo done
+FOO
+
+# the output of "gpg --list-keys --with-colons --fingerprint" looks something like this:
+
+# $ gpg --homedir $TEMPDIR --list-public-keys --with-colons --fingerprint
+# tru::1:1648579633:0:3:1:5
+# pub:-:4096:1:7C5DC8336806E60E:1607727690:1680116664::-:::scESC::::::23::0:
+# fpr:::::::::A9C2E0DFFED2658D75A64D7A7C5DC8336806E60E:
+# uid:-::::1648580664::5F4E53DF54AD0F951384C0F6051B09F3E2BE8496::AWS Flux SWF Client <aws-flux-swf-client-owners@amazon.com>::::::::::0:
+# sub:-:4096:1:D8B3CEEC5C428011:1607727690:1680116665:::::e::::::23:
+# fpr:::::::::FB6E627D30C5B1F4C2177B1BD8B3CEEC5C428011:
+
+# we want the hex string from the fingerprint line just before the uid.
+
+echo "Retrieving key id..."
+FLUX_GPG_KEY_ID=$(gpg --homedir $TEMPDIR --list-public-keys --with-colons --fingerprint | grep -B 1 $FLUX_EMAIL | head -n 1 | cut -d ':' -f 10)
+
+echo "Exporting public key..."
+FLUX_GPG_PUBLIC_KEY=$(gpg --homedir $TEMPDIR --armor --export $FLUX_GPG_KEY_ID)
+
+echo "Exporting private key..."
+FLUX_GPG_PRIVATE_KEY=$(gpg --homedir $TEMPDIR --batch --armor --pinentry-mode loopback --passphrase $FLUX_GPG_PASSPHRASE --export-secret-keys $FLUX_GPG_KEY_ID)
+
+echo "Saving key id in secrets manager..."
+aws secretsmanager create-secret --name gpg-signing-key-id --secret-string "$FLUX_GPG_KEY_ID"
+
+echo "Saving passphrase in secrets manager..."
+aws secretsmanager create-secret --name gpg-signing-key-passphrase --secret-string "$FLUX_GPG_PASSPHRASE"
+
+echo "Saving public key in secrets manager..."
+aws secretsmanager create-secret --name gpg-signing-key-public-key --secret-string "$FLUX_GPG_PUBLIC_KEY"
+
+echo "Saving private key in secrets manager..."
+aws secretsmanager create-secret --name gpg-signing-key-private-key --secret-string "$FLUX_GPG_PRIVATE_KEY"
+
+echo "Sending public key to keys.openpgp.org..."
+gpg --homedir $TEMPDIR --keyserver hkps://keys.openpgp.org --send-keys $FLUX_GPG_KEY_ID
+
+echo "Cleaning up ${TEMPDIR}..."
+rm -rf $TEMPDIR

--- a/scripts/renew-flux-gpg-key.sh
+++ b/scripts/renew-flux-gpg-key.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+set +e
+
+if ! command -v aws &> /dev/null
+then
+  echo "Please install the AWS CLI."
+  exit 1
+fi
+
+if ! command -v jq &> /dev/null
+then
+  echo "Please install jq."
+  exit 2
+fi
+
+if ! command -v gpg &> /dev/null
+then
+  echo "Please install gpg."
+  exit 3
+fi
+
+# you'll also need the AWS CLI to be configured with credentials for our AWS account.
+
+AWS_DEFAULT_REGION=us-west-2
+
+FLUX_GPG_KEY_ID=$(aws secretsmanager get-secret-value --secret-id gpg-signing-key-id | jq -r .SecretString)
+FLUX_GPG_PASSPHRASE=$(aws secretsmanager get-secret-value --secret-id gpg-signing-key-passphrase | jq -r .SecretString)
+FLUX_GPG_PRIVATE_KEY=$(aws secretsmanager get-secret-value --secret-id gpg-signing-key-private-key | jq -r .SecretString)
+
+TEMPDIR=$(mktemp -d)
+echo "Working in ${TEMPDIR}..."
+
+echo "Importing private key"
+gpg --homedir $TEMPDIR --batch --passphrase $FLUX_GPG_PASSPHRASE --import <<EOF
+$FLUX_GPG_PRIVATE_KEY
+EOF
+
+echo "Renewing expiration date..."
+gpg --homedir $TEMPDIR --batch --pinentry-mode loopback --passphrase $FLUX_GPG_PASSPHRASE --command-fd 0 --status-fd 2 --edit-key $FLUX_GPG_KEY_ID <<EOF
+expire
+1y
+key 1
+expire
+1y
+save
+EOF
+
+echo "Exporting renewed public key..."
+FLUX_GPG_PUBLIC_KEY=$(gpg --homedir $TEMPDIR --armor --export $FLUX_GPG_KEY_ID)
+
+echo "Exporting renewed private key..."
+FLUX_GPG_PRIVATE_KEY=$(gpg --homedir $TEMPDIR --batch --armor --pinentry-mode loopback --passphrase $FLUX_GPG_PASSPHRASE --export-secret-keys $FLUX_GPG_KEY_ID)
+
+echo "Saving updated public key in secrets manager..."
+aws secretsmanager put-secret-value --secret-id gpg-signing-key-public-key --secret-string "$FLUX_GPG_PUBLIC_KEY"
+
+echo "Saving updated private key in secrets manager..."
+aws secretsmanager put-secret-value --secret-id gpg-signing-key-private-key --secret-string "$FLUX_GPG_PRIVATE_KEY"
+
+echo "Sending updated public key to keys.openpgp.org..."
+gpg --homedir $TEMPDIR --keyserver hkps://keys.openpgp.org --send-keys $FLUX_GPG_KEY_ID
+
+echo "Cleaning up ${TEMPDIR}..."
+rm -rf $TEMPDIR


### PR DESCRIPTION
* Change buildspec to pull GPG key from Secrets Manager rather than hardcoding it. 
* Change pom to pull GPG key from an environment variable rather than hardcoding it.
* Add scripts for creating a new gpg key, and renewing an existing key.

I already renewed our current gpg key using the renew script.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
