### PR TITLE
Fix tests that occasionally fail due to timing differences in the test code.

### DIFF
--- a/flux/src/test/java/software/amazon/aws/clients/swf/flux/FluxCapacitorTest.java
+++ b/flux/src/test/java/software/amazon/aws/clients/swf/flux/FluxCapacitorTest.java
@@ -16,6 +16,7 @@
 
 package software.amazon.aws.clients.swf.flux;
 
+import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -93,7 +94,7 @@ public class FluxCapacitorTest {
 
         FluxCapacitorConfig config  = new FluxCapacitorConfig();
         config.setSwfDomain(DOMAIN);
-        fc = new FluxCapacitorImpl(new NoopMetricRecorderFactory(), swf, config);
+        fc = new FluxCapacitorImpl(new NoopMetricRecorderFactory(), swf, config, Clock.systemUTC());
         fc.populateNameMaps(Collections.singletonList(workflow));
     }
 
@@ -121,7 +122,7 @@ public class FluxCapacitorTest {
 
         FluxCapacitorConfig config  = new FluxCapacitorConfig();
         config.setSwfDomain(DOMAIN);
-        FluxCapacitorImpl fcCustom = new FluxCapacitorImpl(new NoopMetricRecorderFactory(), swf, config);
+        FluxCapacitorImpl fcCustom = new FluxCapacitorImpl(new NoopMetricRecorderFactory(), swf, config, Clock.systemUTC());
         fcCustom.populateNameMaps(Collections.singletonList(workflowCustomTaskList));
 
         String workflowId = "my-workflow-id";
@@ -150,7 +151,7 @@ public class FluxCapacitorTest {
         FluxCapacitorConfig config  = new FluxCapacitorConfig();
         config.setSwfDomain(DOMAIN);
         config.putTaskListConfig(workflowCustomTaskList.taskList(), taskListConfig);
-        FluxCapacitorImpl fcCustom = new FluxCapacitorImpl(new NoopMetricRecorderFactory(), swf, config);
+        FluxCapacitorImpl fcCustom = new FluxCapacitorImpl(new NoopMetricRecorderFactory(), swf, config, Clock.systemUTC());
         fcCustom.populateNameMaps(Collections.singletonList(workflowCustomTaskList));
 
         String workflowId = "my-workflow-id";
@@ -189,7 +190,7 @@ public class FluxCapacitorTest {
 
         FluxCapacitorConfig config  = new FluxCapacitorConfig();
         config.setSwfDomain(DOMAIN);
-        FluxCapacitorImpl fcCustom = new FluxCapacitorImpl(new NoopMetricRecorderFactory(), swf, config);
+        FluxCapacitorImpl fcCustom = new FluxCapacitorImpl(new NoopMetricRecorderFactory(), swf, config, Clock.systemUTC());
         fcCustom.populateNameMaps(Collections.singletonList(customWorkflow));
 
         String workflowId = "my-workflow-id";
@@ -251,7 +252,7 @@ public class FluxCapacitorTest {
 
         FluxCapacitorConfig config  = new FluxCapacitorConfig();
         config.setSwfDomain(DOMAIN);
-        FluxCapacitor fcNoWorkflows = new FluxCapacitorImpl(new NoopMetricRecorderFactory(), swf, config);
+        FluxCapacitor fcNoWorkflows = new FluxCapacitorImpl(new NoopMetricRecorderFactory(), swf, config, Clock.systemUTC());
 
         Workflow temp = () -> new WorkflowGraphBuilder(new TestStepOne()).successTransition(TestStepOne.class, CloseWorkflow.class).build();
         fc.populateNameMaps(Collections.singletonList(temp));
@@ -273,7 +274,7 @@ public class FluxCapacitorTest {
 
         FluxCapacitorConfig config  = new FluxCapacitorConfig();
         config.setSwfDomain(DOMAIN);
-        FluxCapacitor fcNoWorkflows = new FluxCapacitorImpl(new NoopMetricRecorderFactory(), swf, config);
+        FluxCapacitor fcNoWorkflows = new FluxCapacitorImpl(new NoopMetricRecorderFactory(), swf, config, Clock.systemUTC());
 
         mockery.replay();
         try {

--- a/flux/src/test/java/software/amazon/aws/clients/swf/flux/util/ManualClock.java
+++ b/flux/src/test/java/software/amazon/aws/clients/swf/flux/util/ManualClock.java
@@ -1,0 +1,65 @@
+/*
+ *   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package software.amazon.aws.clients.swf.flux.util;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+
+public class ManualClock extends Clock {
+
+    private Instant curTime;
+
+    public ManualClock() {
+        this.curTime = Instant.now();
+    }
+
+    public ManualClock(Instant startTime) {
+        this.curTime = startTime;
+    }
+
+    @Override
+    public ZoneId getZone() {
+        return ZoneId.systemDefault();
+    }
+
+    @Override
+    public Clock withZone(ZoneId zone) {
+        return this;
+    }
+
+    @Override
+    public Instant instant() {
+        return curTime;
+    }
+
+    @Override
+    public long millis() {
+        return curTime.toEpochMilli();
+    }
+
+    public Instant forward(Duration amount) {
+        curTime = curTime.plus(amount);
+        return curTime;
+    }
+
+    public Instant rewind(Duration amount) {
+        curTime = curTime.minus(amount);
+        return curTime;
+    }
+}


### PR DESCRIPTION
Changes to the real code consist entirely of wiring a `Clock` object into `FluxCapacitorImpl` and all the way down into the guts of the code, and then changing all calls to `Instant.now()` to `clock.instant()`. By default, `Clock.systemUTC()` is used, since we've been assuming UTC all along anyway.

The test code now uses a custom `ManualClock` that allows the test to carefully modify the timestamp used at any given time.

Prior to making this change, I was able to occasionally reproduce a failure like the one mentioned in the issue; after this change, I have not been able to reproduce it.

*Issue #, if available:* [50](https://github.com/awslabs/flux-swf-client/issues/50)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
