### PR TITLE
#167 Add workflow introspection in WorkflowStepHook

### DIFF
--- a/flux-common/src/main/java/com/danielgmyers/flux/step/internal/ActivityExecutionUtil.java
+++ b/flux-common/src/main/java/com/danielgmyers/flux/step/internal/ActivityExecutionUtil.java
@@ -41,12 +41,13 @@ public final class ActivityExecutionUtil {
      * @return The result of the step execution.
      */
     public static StepResult executeActivity(WorkflowStep step, String activityName, MetricRecorder fluxMetrics,
-                                             MetricRecorder stepMetrics, StepInputAccessor input) {
+                                             MetricRecorder stepMetrics, StepInputAccessor input, Workflow workflow) {
         StepResult result;
         String retryExceptionCauseName = null;
         try {
             Method applyMethod = WorkflowStepUtil.getUniqueAnnotatedMethod(step.getClass(), StepApply.class);
-            Object returnObject = applyMethod.invoke(step, WorkflowStepUtil.generateArguments(step.getClass(), applyMethod,
+            Object returnObject = applyMethod.invoke(step, WorkflowStepUtil.generateArguments(step.getClass(), workflow,
+                                                                                              step, applyMethod,
                                                                                               stepMetrics, input,
                                                                                               Collections.emptyMap()));
             // if apply didn't throw an exception, then we can assume success.
@@ -95,11 +96,11 @@ public final class ActivityExecutionUtil {
             StepResult result = null;
             if (hooks != null && step.getClass() != PostWorkflowHookAnchor.class) {
                 result = WorkflowStepUtil.executeHooks(hooks, stepInput, hookInput, StepHook.HookType.PRE, activityName,
-                        fluxMetrics, stepMetrics);
+                        fluxMetrics, stepMetrics, workflow, step);
             }
 
             if (result == null) {
-                result = executeActivity(step, activityName, fluxMetrics, stepMetrics, stepInput);
+                result = executeActivity(step, activityName, fluxMetrics, stepMetrics, stepInput, workflow);
 
                 hookInput.putAll(result.getAttributes());
 
@@ -113,7 +114,7 @@ public final class ActivityExecutionUtil {
 
                 if (hooks != null && step.getClass() != PreWorkflowHookAnchor.class) {
                     StepResult hookResult = WorkflowStepUtil.executeHooks(hooks, stepInput, hookInput, StepHook.HookType.POST,
-                            activityName, fluxMetrics, stepMetrics);
+                            activityName, fluxMetrics, stepMetrics, workflow, step);
                     if (hookResult != null) {
                         log.info("Activity {} returned result {} ({}) but a post-step hook requires a retry ({}).",
                                 activityName, result.getResultCode(), result.getMessage(),

--- a/flux-common/src/main/java/com/danielgmyers/flux/step/internal/WorkflowStepUtil.java
+++ b/flux-common/src/main/java/com/danielgmyers/flux/step/internal/WorkflowStepUtil.java
@@ -35,7 +35,9 @@ import com.danielgmyers.flux.step.PartitionedWorkflowStep;
 import com.danielgmyers.flux.step.StepHook;
 import com.danielgmyers.flux.step.StepInputAccessor;
 import com.danielgmyers.flux.step.StepResult;
+import com.danielgmyers.flux.step.WorkflowStep;
 import com.danielgmyers.flux.step.WorkflowStepHook;
+import com.danielgmyers.flux.wf.Workflow;
 import com.danielgmyers.metrics.MetricRecorder;
 import com.danielgmyers.metrics.MetricRecorderFactory;
 import org.slf4j.Logger;
@@ -104,7 +106,8 @@ public final class WorkflowStepUtil {
     public static PartitionIdGeneratorResult getPartitionIdsForPartitionedStep(PartitionedWorkflowStep step,
                                                                                StepInputAccessor stepInput,
                                                                                String workflowName, String workflowId,
-                                                                               MetricRecorderFactory metricsFactory) {
+                                                                               MetricRecorderFactory metricsFactory,
+                                                                               Workflow workflow) {
         String activityName = TaskNaming.activityName(workflowName, step);
         Method partitionIdMethod = WorkflowStepUtil.getUniqueAnnotatedMethod(step.getClass(), PartitionIdGenerator.class);
         try (MetricRecorder stepMetrics = metricsFactory.newMetricRecorder(activityName + "." + partitionIdMethod.getName())) {
@@ -114,7 +117,7 @@ public final class WorkflowStepUtil {
                                                          step.getClass().getSimpleName(), partitionIdMethod.getName()));
             }
 
-            Object[] arguments = WorkflowStepUtil.generateArguments(step.getClass(), partitionIdMethod, stepMetrics,
+            Object[] arguments = WorkflowStepUtil.generateArguments(step.getClass(), workflow, step, partitionIdMethod, stepMetrics,
                                                                     stepInput, Collections.emptyMap());
             return (PartitionIdGeneratorResult)(partitionIdMethod.invoke(step, arguments));
         } catch (IllegalAccessException | InvocationTargetException e) {
@@ -132,13 +135,20 @@ public final class WorkflowStepUtil {
      *
      * Attributes from additionalInputs take precedence over attributes from stepInput if present in both.
      */
-    public static Object[] generateArguments(Class<?> clazz, Method method, MetricRecorder metrics,
+    public static Object[] generateArguments(Class<?> clazz, Workflow workflow, WorkflowStep step,
+                                             Method method, MetricRecorder metrics,
                                              StepInputAccessor stepInput, Map<String, Object> additionalInputs) {
         Object[] args = new Object[method.getParameterCount()];
 
+        boolean isStepHook = WorkflowStepHook.class.isAssignableFrom(clazz);
+
         int arg = 0;
         for (Parameter param : method.getParameters()) {
-            if (param.getType().isAssignableFrom(MetricRecorder.class)) {
+            if (isStepHook && param.getType().equals(Workflow.class)) {
+                args[arg] = workflow;
+            } else if (isStepHook && param.getType().equals(WorkflowStep.class)) {
+                args[arg] = step;
+            } else if (param.getType().isAssignableFrom(MetricRecorder.class)) {
                 args[arg] = metrics;
             } else {
                 Attribute attr = param.getAnnotation(Attribute.class);
@@ -173,7 +183,8 @@ public final class WorkflowStepUtil {
      */
     public static StepResult executeHooks(List<WorkflowStepHook> hooks, StepInputAccessor stepInput,
                                           Map<String, Object> specialHookInputs, StepHook.HookType hookType,
-                                          String activityName, MetricRecorder fluxMetrics, MetricRecorder hookMetrics) {
+                                          String activityName, MetricRecorder fluxMetrics, MetricRecorder hookMetrics,
+                                          Workflow workflow, WorkflowStep step) {
         for (WorkflowStepHook hook : hooks) {
             Map<Method, StepHook> methods = WorkflowStepUtil.getAllMethodsWithAnnotation(hook.getClass(), StepHook.class);
             for (Map.Entry<Method, StepHook> method : methods.entrySet()) {
@@ -185,6 +196,8 @@ public final class WorkflowStepUtil {
                 fluxMetrics.startDuration(hookExecutionTimeMetricName);
                 try {
                     Object result = method.getKey().invoke(hook, WorkflowStepUtil.generateArguments(hook.getClass(),
+                                                                                                    workflow,
+                                                                                                    step,
                                                                                                     method.getKey(),
                                                                                                     hookMetrics,
                                                                                                     stepInput,

--- a/flux-common/src/test/java/com/danielgmyers/flux/step/internal/ActivityExecutionUtilTest.java
+++ b/flux-common/src/test/java/com/danielgmyers/flux/step/internal/ActivityExecutionUtilTest.java
@@ -79,7 +79,7 @@ public class ActivityExecutionUtilTest {
         StepResult expectedResult = makeStepResult(StepResult.ResultAction.COMPLETE, StepResult.SUCCEED_RESULT_CODE, "yay", output);
 
         String activityName = TaskNaming.activityName(workflow, step);
-        StepResult actualResult = ActivityExecutionUtil.executeActivity(step, activityName, fluxMetrics, stepMetrics, emptyInput);
+        StepResult actualResult = ActivityExecutionUtil.executeActivity(step, activityName, fluxMetrics, stepMetrics, emptyInput, workflow);
         Assertions.assertTrue(step.didThing());
 
         // fluxMetrics needs to be closed by the caller to executeActivity.
@@ -103,7 +103,7 @@ public class ActivityExecutionUtilTest {
         step.setStepResult(expectedResult);
 
         String activityName = TaskNaming.activityName(workflow, step);
-        StepResult actualResult = ActivityExecutionUtil.executeActivity(step, activityName, fluxMetrics, stepMetrics, emptyInput);
+        StepResult actualResult = ActivityExecutionUtil.executeActivity(step, activityName, fluxMetrics, stepMetrics, emptyInput, workflow);
         Assertions.assertTrue(step.didThing()); // true because the step did a thing before specifically deciding to return retry
 
         // fluxMetrics needs to be closed by the caller to executeActivity.
@@ -129,7 +129,7 @@ public class ActivityExecutionUtilTest {
         StepResult expectedResult = StepResult.retry(e);
 
         String activityName = TaskNaming.activityName(workflow, step);
-        StepResult actualResult = ActivityExecutionUtil.executeActivity(step, activityName, fluxMetrics, stepMetrics, emptyInput);
+        StepResult actualResult = ActivityExecutionUtil.executeActivity(step, activityName, fluxMetrics, stepMetrics, emptyInput, workflow);
         Assertions.assertFalse(step.didThing()); // false because the step threw an exception in the middle of doing the thing
 
         // fluxMetrics needs to be closed by the caller to executeActivity.
@@ -176,7 +176,7 @@ public class ActivityExecutionUtilTest {
         };
 
         String activityName = TaskNaming.activityName(workflow, stepWithSeveralInputs);
-        StepResult actualResult = ActivityExecutionUtil.executeActivity(stepWithSeveralInputs, activityName, fluxMetrics, stepMetrics, inputAccessor);
+        StepResult actualResult = ActivityExecutionUtil.executeActivity(stepWithSeveralInputs, activityName, fluxMetrics, stepMetrics, inputAccessor, workflow);
 
         // The stub step has a return type of void, so it should always just be a plain success result.
         Assertions.assertEquals(StepResult.success(), actualResult);
@@ -213,7 +213,7 @@ public class ActivityExecutionUtilTest {
         Workflow workflow = new TestWorkflow(graph.build());
 
         String activityName = TaskNaming.activityName(workflow, stepWithMetrics);
-        StepResult actualResult = ActivityExecutionUtil.executeActivity(stepWithMetrics, activityName, fluxMetrics, stepMetrics, emptyInput);
+        StepResult actualResult = ActivityExecutionUtil.executeActivity(stepWithMetrics, activityName, fluxMetrics, stepMetrics, emptyInput, workflow);
 
         // The stub step has a return type of void, so it should always just be a plain success result.
         Assertions.assertEquals(StepResult.success(), actualResult);
@@ -311,6 +311,23 @@ public class ActivityExecutionUtilTest {
 
         Assertions.assertEquals(1, fluxMetrics.getCounts().get(ActivityExecutionUtil.formatCompletionResultMetricName(TaskNaming.activityName(workflow, step),
                 expectedResult.getResultCode())).intValue());
+    }
+
+    @Test
+    public void testStepHooksIntrospectObjects() {
+        WorkflowStepHook hook = new TestHookWithIntrospection(TestWorkflow.class, DummyStep.class);
+        WorkflowGraphBuilder builder = new WorkflowGraphBuilder(step);
+        builder.alwaysClose(step);
+        builder.addStepHook(step, hook);
+
+        Workflow workflow = new TestWorkflow(builder.build());
+
+        Map<String, Object> output = Collections.emptyMap();
+        StepResult expectedResult = makeStepResult(StepResult.ResultAction.COMPLETE, StepResult.SUCCEED_RESULT_CODE, "yay", output);
+        step.setStepResult(expectedResult);
+
+        StepResult actualResult = ActivityExecutionUtil.executeHooksAndActivity(workflow, step, emptyInput, fluxMetrics, stepMetrics);
+        Assertions.assertTrue(step.didThing());
     }
 
     @Test
@@ -693,6 +710,34 @@ public class ActivityExecutionUtilTest {
             metrics.addCount(POST_HOOK_METRIC_NAME, 1.0);
         }
 
+    }
+
+    public static class TestHookWithIntrospection implements WorkflowStepHook {
+        private final Class<? extends Workflow> expectedWorkflowClass;
+        private final Class<? extends WorkflowStep> expectedStepClass;
+
+        TestHookWithIntrospection(Class<? extends Workflow> expectedWorkflowClass, Class<? extends WorkflowStep> expectedStepClass) {
+            this.expectedWorkflowClass = expectedWorkflowClass;
+            this.expectedStepClass = expectedStepClass;
+        }
+
+        @StepHook(hookType = StepHook.HookType.PRE)
+        public void preStepHook(Workflow workflow, WorkflowStep step) {
+            Assertions.assertNotNull(workflow);
+            Assertions.assertNotNull(step);
+
+            Assertions.assertInstanceOf(expectedWorkflowClass, workflow);
+            Assertions.assertInstanceOf(expectedStepClass, step);
+        }
+
+        @StepHook(hookType = StepHook.HookType.POST)
+        public void postStepHook(Workflow workflow, WorkflowStep step) {
+            Assertions.assertNotNull(workflow);
+            Assertions.assertNotNull(step);
+
+            Assertions.assertInstanceOf(expectedWorkflowClass, workflow);
+            Assertions.assertInstanceOf(expectedStepClass, step);
+        }
     }
 
     public static class TestPreHookThrowsExceptionNoRetryOnFailure implements WorkflowStepHook {

--- a/flux-swf/src/main/java/com/danielgmyers/flux/clients/swf/poller/DecisionTaskPoller.java
+++ b/flux-swf/src/main/java/com/danielgmyers/flux/clients/swf/poller/DecisionTaskPoller.java
@@ -475,7 +475,7 @@ public class DecisionTaskPoller implements Runnable {
             // response, which may reduce the number of partitions we could schedule.
             PartitionIdGeneratorResult result
                     = WorkflowStepUtil.getPartitionIdsForPartitionedStep((PartitionedWorkflowStep)nextStep, nextStepInput,
-                                                                         workflowName, workflowId, metricsFactory);
+                                                                         workflowName, workflowId, metricsFactory, workflow);
             PartitionMetadata metadata = PartitionMetadata.fromPartitionIdGeneratorResult(result);
 
             for (String partitionId : metadata.getPartitionIds()) {

--- a/flux-swf/src/test/java/com/danielgmyers/flux/clients/swf/poller/WorkflowHistoryBuilder.java
+++ b/flux-swf/src/test/java/com/danielgmyers/flux/clients/swf/poller/WorkflowHistoryBuilder.java
@@ -407,7 +407,7 @@ public class WorkflowHistoryBuilder {
                     }
                 };
 
-                PartitionIdGeneratorResult result = WorkflowStepUtil.getPartitionIdsForPartitionedStep(partitionedStep, stepInput, workflowName, WORKFLOW_ID, new NoopMetricRecorderFactory());
+                PartitionIdGeneratorResult result = WorkflowStepUtil.getPartitionIdsForPartitionedStep(partitionedStep, stepInput, workflowName, WORKFLOW_ID, new NoopMetricRecorderFactory(), workflow);
                 if (result.getPartitionIds().isEmpty() || result.getPartitionIds().contains(null)) {
                     throw new IllegalArgumentException();
                 }

--- a/flux-testutils/src/main/java/com/danielgmyers/flux/testutil/StepValidator.java
+++ b/flux-testutils/src/main/java/com/danielgmyers/flux/testutil/StepValidator.java
@@ -90,9 +90,10 @@ public final class StepValidator {
             }
         };
 
+        // It is alright to pass null as the workflow here as this method doesn't invoke step hooks
         StepResult actual = ActivityExecutionUtil.executeActivity(step, step.getClass().getSimpleName(),
                                                                   METRICS_FACTORY.newMetricRecorder(""), stepMetrics,
-                                                                  stepInput);
+                                                                  stepInput, null);
         if (actual.getAction() != expectedResult) {
             throw new RuntimeException(String.format("Expected result action %s but was %s: %s",
                                                      expectedResult, actual.getAction(), actual.getMessage()),


### PR DESCRIPTION
Resolves #167. Adds type resolution for Workflow and WorkflowStep in WorkflowStepUtil.generateArguments, the resolution for these argument types only happens if the target class is derived from WorkflowStepHook as I'm unsure if a step being able to inspect itself is a desirable property.

I added a test to cover this logic as well, and all tests pass with the change
```
[INFO] Reactor Summary:
[INFO] 
[INFO] Flux Workflow Client Base POM 0 .................... SUCCESS [  0.705 s]
[INFO] Flux Workflow Client Common 2.1.0 .................. SUCCESS [  2.175 s]
[INFO] Flux Workflow Client Test Utils 2.1.0 .............. SUCCESS [  0.959 s]
[INFO] Flux Workflow Client Common (AWS) 2.1.0 ............ SUCCESS [  0.648 s]
[INFO] Flux SWF Client 2.1.0 .............................. SUCCESS [ 23.857 s]
[INFO] Flux SWF Client Guice Helper 2.1.0 ................. SUCCESS [  1.164 s]
[INFO] Flux SWF Client integration tests 2.1.0 ............ SUCCESS [  0.040 s]
[INFO] Flux SWF Client Spring Helper 2.1.0 ................ SUCCESS [  1.112 s]
[INFO] Flux Step Functions Client 1.0.0 ................... SUCCESS [ 23.141 s]
[INFO] Flux Step Functions Client Guice Helper 1.0.0 ...... SUCCESS [  0.037 s]
[INFO] Flux Step Functions Client integration tests 1.0.0 . SUCCESS [  0.031 s]
[INFO] Flux Step Functions Client Spring Helper 1.0.0 ..... SUCCESS [  0.038 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  54.001 s
[INFO] Finished at: 2026-05-15T13:26:05Z
[INFO] ------------------------------------------------------------------------
```