### PR TITLE
Bump flux-common and flux-swf to 2.1.1.

### DIFF
--- a/flux-common-aws/pom.xml
+++ b/flux-common-aws/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>com.danielgmyers.flux</groupId>
             <artifactId>flux-common</artifactId>
-            <version>${flux.base.version}</version>
+            <version>${flux.awscommon.depver.flux-common}</version>
         </dependency>
 
         <!-- test dependencies -->

--- a/flux-common/pom.xml
+++ b/flux-common/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>com.danielgmyers.flux</groupId>
     <artifactId>flux-common</artifactId>
-    <version>${flux.base.version}</version>
+    <version>${flux.common.version}</version>
     <name>Flux Workflow Client Common</name>
     <description>Flux is a workflow client library to simplify writing asynchronous workflows.</description>
     <url>https://github.com/danielgmyers/flux-swf-client</url>

--- a/flux-sfn-guice/pom.xml
+++ b/flux-sfn-guice/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>com.danielgmyers.flux.clients.sfn</groupId>
     <artifactId>flux-sfn-guice</artifactId>
-    <version>${flux.sfn.version}</version>
+    <version>${flux.sfn-guice.version}</version>
     <name>Flux Step Functions Client Guice Helper</name>
     <description>Flux Step Functions Client Guice Helper makes Flux initialization easier when using Guice.</description>
     <url>https://github.com/danielgmyers/flux-swf-client</url>
@@ -43,7 +43,7 @@
         <dependency>
             <artifactId>flux-sfn</artifactId>
             <groupId>com.danielgmyers.flux.clients.sfn</groupId>
-            <version>${flux.sfn.version}</version>
+            <version>${flux.sfn-guice.depver.flux-sfn}</version>
             <optional>false</optional>
         </dependency>
 

--- a/flux-sfn-spring/pom.xml
+++ b/flux-sfn-spring/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>com.danielgmyers.flux.clients.sfn</groupId>
     <artifactId>flux-sfn-spring</artifactId>
-    <version>${flux.sfn.version}</version>
+    <version>${flux.sfn-spring.version}</version>
     <name>Flux Step Functions Client Spring Helper</name>
     <description>Flux Step Functions Client Spring Helper makes Flux initialization easier when using Spring.</description>
     <url>https://github.com/danielgmyers/flux-swf-client</url>
@@ -38,7 +38,7 @@
         <dependency>
             <artifactId>flux-sfn</artifactId>
             <groupId>com.danielgmyers.flux.clients.sfn</groupId>
-            <version>${flux.sfn.version}</version>
+            <version>${flux.sfn-spring.depver.flux-sfn}</version>
             <optional>false</optional>
         </dependency>
 

--- a/flux-sfn/pom.xml
+++ b/flux-sfn/pom.xml
@@ -68,13 +68,13 @@
         <dependency>
             <artifactId>flux-common</artifactId>
             <groupId>com.danielgmyers.flux</groupId>
-            <version>${flux.base.version}</version>
+            <version>${flux.sfn.depver.flux-common}</version>
             <optional>false</optional>
         </dependency>
         <dependency>
             <artifactId>flux-common-aws</artifactId>
             <groupId>com.danielgmyers.flux</groupId>
-            <version>${flux.awscommon.version}</version>
+            <version>${flux.sfn.depver.flux-awscommon}</version>
             <optional>false</optional>
         </dependency>
 
@@ -106,7 +106,7 @@
         <dependency>
             <artifactId>flux-testutils</artifactId>
             <groupId>com.danielgmyers.flux</groupId>
-            <version>${flux.base.version}</version>
+            <version>${flux.sfn.depver.flux-testutils}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/flux-swf-guice/pom.xml
+++ b/flux-swf-guice/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>com.danielgmyers.flux.clients.swf</groupId>
     <artifactId>flux-swf-guice</artifactId>
-    <version>${flux.swf.version}</version>
+    <version>${flux.swf-guice.version}</version>
     <name>Flux SWF Client Guice Helper</name>
     <description>Flux SWF Client Guice Helper makes Flux initialization easier when using Guice.</description>
     <url>https://github.com/danielgmyers/flux-swf-client</url>
@@ -42,7 +42,7 @@
         <dependency>
             <artifactId>flux-swf</artifactId>
             <groupId>com.danielgmyers.flux.clients.swf</groupId>
-            <version>${flux.swf.version}</version>
+            <version>${flux.swf-guice.depver.flux-swf}</version>
             <optional>false</optional>
         </dependency>
 

--- a/flux-swf-spring/pom.xml
+++ b/flux-swf-spring/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>com.danielgmyers.flux.clients.swf</groupId>
     <artifactId>flux-swf-spring</artifactId>
-    <version>${flux.swf.version}</version>
+    <version>${flux.swf-spring.version}</version>
     <name>Flux SWF Client Spring Helper</name>
     <description>Flux SWF Client Spring Helper makes Flux initialization easier when using Spring.</description>
     <url>https://github.com/danielgmyers/flux-swf-client</url>
@@ -39,7 +39,7 @@
         <dependency>
             <artifactId>flux-swf</artifactId>
             <groupId>com.danielgmyers.flux.clients.swf</groupId>
-            <version>${flux.swf.version}</version>
+            <version>${flux.swf-spring.depver.flux-swf}</version>
             <optional>false</optional>
         </dependency>
 
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>com.danielgmyers.flux</groupId>
             <artifactId>flux-testutils</artifactId>
-            <version>${flux.base.version}</version>
+            <version>${flux.swf-spring.depver.flux-testutils}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/flux-swf/pom.xml
+++ b/flux-swf/pom.xml
@@ -67,13 +67,13 @@
         <dependency>
             <artifactId>flux-common</artifactId>
             <groupId>com.danielgmyers.flux</groupId>
-            <version>${flux.base.version}</version>
+            <version>${flux.swf.depver.flux-common}</version>
             <optional>false</optional>
         </dependency>
         <dependency>
             <artifactId>flux-common-aws</artifactId>
             <groupId>com.danielgmyers.flux</groupId>
-            <version>${flux.awscommon.version}</version>
+            <version>${flux.swf.depver.flux-awscommon}</version>
             <optional>false</optional>
         </dependency>
 
@@ -105,7 +105,7 @@
         <dependency>
             <artifactId>flux-testutils</artifactId>
             <groupId>com.danielgmyers.flux</groupId>
-            <version>${flux.base.version}</version>
+            <version>${flux.swf.depver.flux-testutils}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/flux-testutils/pom.xml
+++ b/flux-testutils/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>com.danielgmyers.flux</groupId>
     <artifactId>flux-testutils</artifactId>
-    <version>${flux.base.version}</version>
+    <version>${flux.testutils.version}</version>
     <name>Flux Workflow Client Test Utils</name>
     <description>Flux Workflow Client Test Utils provides helper code for writing tests against the Flux interfaces.</description>
     <url>https://github.com/danielgmyers/flux-swf-client</url>
@@ -31,7 +31,7 @@
         <dependency>
             <artifactId>flux-common</artifactId>
             <groupId>com.danielgmyers.flux</groupId>
-            <version>${flux.base.version}</version>
+            <version>${flux.testutils.depver.flux-common}</version>
             <optional>false</optional>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -55,10 +55,36 @@
     </scm>
     <properties>
         <!-- Flux's components get their own versions so that we can release them separately as needed. -->
-        <flux.base.version>2.1.0</flux.base.version>
+        <flux.common.version>2.1.1</flux.common.version>
+
+        <flux.testutils.version>2.1.1</flux.testutils.version>
+        <flux.testutils.depver.flux-common>[2.1.1,)</flux.testutils.depver.flux-common>
+
         <flux.awscommon.version>2.1.0</flux.awscommon.version>
-        <flux.swf.version>2.1.0</flux.swf.version>
+        <flux.awscommon.depver.flux-common>2.1.0</flux.awscommon.depver.flux-common>
+
+        <flux.swf.version>2.1.1</flux.swf.version>
+        <flux.swf.depver.flux-common>[2.1.1,)</flux.swf.depver.flux-common>
+        <flux.swf.depver.flux-awscommon>2.1.0</flux.swf.depver.flux-awscommon>
+        <flux.swf.depver.flux-testutils>[2.1.1,)</flux.swf.depver.flux-testutils>
+
+        <flux.swf-guice.version>2.1.0</flux.swf-guice.version>
+        <flux.swf-guice.depver.flux-swf>2.1.0</flux.swf-guice.depver.flux-swf>
+
+        <flux.swf-spring.version>2.1.0</flux.swf-spring.version>
+        <flux.swf-spring.depver.flux-swf>2.1.0</flux.swf-spring.depver.flux-swf>
+        <flux.swf-spring.depver.flux-testutils>2.1.0</flux.swf-spring.depver.flux-testutils>
+
         <flux.sfn.version>1.0.0</flux.sfn.version>
+        <flux.sfn.depver.flux-common>[2.1.1,)</flux.sfn.depver.flux-common>
+        <flux.sfn.depver.flux-awscommon>2.1.0</flux.sfn.depver.flux-awscommon>
+        <flux.sfn.depver.flux-testutils>2.1.0</flux.sfn.depver.flux-testutils>
+
+        <flux.sfn-guice.version>1.0.0</flux.sfn-guice.version>
+        <flux.sfn-guice.depver.flux-sfn>1.0.0</flux.sfn-guice.depver.flux-sfn>
+
+        <flux.sfn-spring.version>1.0.0</flux.sfn-spring.version>
+        <flux.sfn-spring.depver.flux-sfn>1.0.0</flux.sfn-spring.depver.flux-sfn>
 
         <awssdk.version>2.25.67</awssdk.version>
         <commons-codec.version>1.15</commons-codec.version>


### PR DESCRIPTION
Added a bunch of version controls to the base pom so specific dependency versions can be required for different components.

In this case, flux-swf now explicitly requires flux-common>=2.1.1 but flux-sfn is still fine with 2.1.0.