### PR TITLE
[#170, #151] Add hook result output parameters and result overriding

### DIFF
--- a/flux-common/src/main/java/com/danielgmyers/flux/step/HookResult.java
+++ b/flux-common/src/main/java/com/danielgmyers/flux/step/HookResult.java
@@ -1,0 +1,168 @@
+/*
+ *   Copyright Flux Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.danielgmyers.flux.step;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import com.danielgmyers.flux.step.StepResult.ResultAction;
+
+/**
+ * The result of executing a step hook.
+ *
+ * Returning a {@link #proceed()} object from a {@link StepHook.HookType#PRE} or {@link StepHook.HookType#POST}
+ * step hook will have no effect on the steps execution but does allow injecting
+ * extra step attributes with {@link #withAttribute(String, Object)}.
+ *
+ * Returning a {@link #retry()} object from a {@link StepHook.HookType#PRE} step hook will prevent the step
+ * from being executed and will schedule a retry. If any step hook returns a retry the step will
+ * retry, even if a subsequent step hook returns a {@link #complete()}.
+ *
+ * Returning a {@link #complete()} object from a {@link StepHook.HookType#PRE} step hook will prevent the step
+ * from being executed and will immediately schedule the next step to be executed. Any extra attributes
+ * attached to the result will be passed to the next step. When returned from a {@link StepHook.HookType#POST}
+ * step hook this allows you to override a step that retried with a successful result.
+ *
+ * If multiple step hooks are registered their execution order is indeterminate. All step hooks will be executed
+ * unless one fails by throwing an exception and does not have {@link StepHook#retryOnFailure()} set to {@code true}.
+ *
+ * If any step hook returns {@link #retry()} then the step will always retry. If a step hook responds with {@link #complete()}
+ * and no step hook responds with {@link #retry()} then the step will be successful, even if the step itself returned a retry.
+ * Returning {@link #proceed()} will never affect the response of a step, aside from allowing attachment of extra attributes.
+ */
+public final class HookResult {
+    private final ResultAction action;
+    private final String resultCode;
+    private final String message;
+    private final Map<String, Object> attributes;
+
+    /**
+     * Continue execution and do not modify the result of this step.
+     *
+     * All step hooks after this will be executed as normal, any attributes saved on this result
+     * will be added to the steps resulting set of attributes.
+     *
+     * @return A hook result that represents a 'continue' decision.
+     */
+    public static HookResult proceed() {
+        return new HookResult(null, null, null);
+    }
+
+    /**
+     * Override the result of the step and return a retry instead.
+     *
+     * @return A hook result that represents a 'retry' decision.
+     */
+    public static HookResult retry() {
+        return retry(null);
+    }
+
+    public static HookResult retry(final String message) {
+        return retry(null, message);
+    }
+
+    public static HookResult retry(final String resultCode, final String message) {
+        return new HookResult(ResultAction.RETRY, resultCode, message);
+    }
+
+    /**
+     * Override the result of the step and return a success instead.
+     *
+     * @return A hook result that represents a 'success' decision.
+     */
+    public static HookResult complete() {
+        return complete(null);
+    }
+
+    public static HookResult complete(final String message) {
+        return complete(null, message);
+    }
+
+    public static HookResult complete(final String resultCode, final String message) {
+        return new HookResult(ResultAction.COMPLETE, resultCode, message);
+    }
+
+    /**
+     * Attach an extra attribute to this hook that will be injected into the step attributes.
+     *
+     * If used in a {@link StepHook.HookType#PRE} hook the attributes will be available to the executing
+     * step. If used in a {@link StepHook.HookType#POST} hook the attributes will be available to the next
+     * step.
+     *
+     * @param name The name of the attribute
+     * @param value The value of the attribute
+     */
+    public void addAttribute(final String name, final Object value) {
+        throwIfActionIsNotSucceed();
+        attributes.put(name, value);
+    }
+
+    public HookResult withAttribute(final String name, final Object value) {
+        addAttribute(name, value);
+        return this;
+    }
+
+    public HookResult withAllAttributes(final Map<? extends String, ? extends Object> values) {
+        throwIfActionIsNotSucceed();
+        attributes.putAll(values);
+        return this;
+    }
+
+    public ResultAction getAction() {
+        return action;
+    }
+
+    public String getResultCode() {
+        return resultCode;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public Map<String, Object> getAttributes() {
+        return Collections.unmodifiableMap(attributes);
+    }
+
+    private HookResult(final ResultAction action, final String resultCode, final String message) {
+        if (action == null && (resultCode != null || message != null)) {
+            throw new IllegalArgumentException("Result codes must be null when a hook doesnt override the steps result");
+        }
+
+        this.action = action;
+        this.resultCode = resultCode;
+        this.message = message;
+        this.attributes = new HashMap<>();
+    }
+
+    private void throwIfActionIsNotSucceed() {
+        if (action == ResultAction.RETRY) {
+            throw new IllegalArgumentException("Attributes cannot be added to Retry or Continue step results.");
+        }
+    }
+
+    @Override
+    public String toString() {
+        // Attributes are omitted from the string here, in case they contain sensitive information.
+        return "HookResult[action="
+            + action
+            + ", resultCode=" + resultCode
+            + ", message=" + message + "]";
+    }
+}

--- a/flux-common/src/main/java/com/danielgmyers/flux/step/StepHook.java
+++ b/flux-common/src/main/java/com/danielgmyers/flux/step/StepHook.java
@@ -36,7 +36,8 @@ import java.lang.annotation.Target;
  * Otherwise, Flux handles the exception the same way it would handle it if it had been thrown by the @StepApply method;
  * specifically, it causes the entire step to retry. The subsequent attempt will execute all hooks again, as normal.
  *
- * The return value of the method is logged but otherwise ignored, so the return type does not matter.
+ * If the return type of the method is {@link HookResult} then the result can be used to either fast-fail a step when
+ * used with a PRE hook, or to cause a step to retry when used with a POST hook.
  */
 @Target({ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)

--- a/flux-common/src/main/java/com/danielgmyers/flux/step/internal/ActivityExecutionUtil.java
+++ b/flux-common/src/main/java/com/danielgmyers/flux/step/internal/ActivityExecutionUtil.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.danielgmyers.flux.poller.TaskNaming;
+import com.danielgmyers.flux.step.HookResult;
 import com.danielgmyers.flux.step.StepApply;
 import com.danielgmyers.flux.step.StepAttributes;
 import com.danielgmyers.flux.step.StepHook;
@@ -15,6 +16,7 @@ import com.danielgmyers.flux.step.StepInputAccessor;
 import com.danielgmyers.flux.step.StepResult;
 import com.danielgmyers.flux.step.WorkflowStep;
 import com.danielgmyers.flux.step.WorkflowStepHook;
+import com.danielgmyers.flux.step.StepResult.ResultAction;
 import com.danielgmyers.flux.wf.Workflow;
 import com.danielgmyers.flux.wf.graph.PostWorkflowHookAnchor;
 import com.danielgmyers.flux.wf.graph.PreWorkflowHookAnchor;
@@ -87,6 +89,7 @@ public final class ActivityExecutionUtil {
     public static StepResult executeHooksAndActivity(Workflow workflow, WorkflowStep step, StepInputAccessor stepInput,
                                                      MetricRecorder fluxMetrics, MetricRecorder stepMetrics) {
         String activityName = TaskNaming.activityName(workflow, step);
+        ExecutionAttributes attributes = new ExecutionAttributes(stepInput);
         try {
             List<WorkflowStepHook> hooks = workflow.getGraph().getHooksForStep(step.getClass());
 
@@ -95,12 +98,16 @@ public final class ActivityExecutionUtil {
 
             StepResult result = null;
             if (hooks != null && step.getClass() != PostWorkflowHookAnchor.class) {
-                result = WorkflowStepUtil.executeHooks(hooks, stepInput, hookInput, StepHook.HookType.PRE, activityName,
+                HookResult hookResult = WorkflowStepUtil.executeHooks(hooks, attributes, hookInput, StepHook.HookType.PRE, activityName,
                         fluxMetrics, stepMetrics, workflow, step);
+
+                if (hookResult != null) {
+                    result = stepResultFromHookResult(hookResult);
+                }
             }
 
             if (result == null) {
-                result = executeActivity(step, activityName, fluxMetrics, stepMetrics, stepInput, workflow);
+                result = executeActivity(step, activityName, fluxMetrics, stepMetrics, attributes, workflow);
 
                 hookInput.putAll(result.getAttributes());
 
@@ -111,17 +118,41 @@ public final class ActivityExecutionUtil {
                 if (result.getResultCode() != null) {
                     hookInput.put(StepAttributes.RESULT_CODE, result.getResultCode());
                 }
+            }
 
-                if (hooks != null && step.getClass() != PreWorkflowHookAnchor.class) {
-                    StepResult hookResult = WorkflowStepUtil.executeHooks(hooks, stepInput, hookInput, StepHook.HookType.POST,
-                            activityName, fluxMetrics, stepMetrics, workflow, step);
-                    if (hookResult != null) {
-                        log.info("Activity {} returned result {} ({}) but a post-step hook requires a retry ({}).",
-                                activityName, result.getResultCode(), result.getMessage(),
-                                hookResult.getMessage());
-                        return hookResult;
-                    }
+            if (hooks != null && step.getClass() != PreWorkflowHookAnchor.class) {
+                HookResult hookResult = WorkflowStepUtil.executeHooks(hooks, attributes, hookInput, StepHook.HookType.POST,
+                        activityName, fluxMetrics, stepMetrics, workflow, step);
+                if (hookResult != null && ResultAction.RETRY.equals(hookResult.getAction())) {
+                    log.info("Activity {} returned result {} ({}) but a post-step hook requires a retry ({}).",
+                            activityName, result.getResultCode(), result.getMessage(),
+                            hookResult.getMessage());
+
+                    //
+                    // This purposefully drops any attributes the step added since they leaking into
+                    // the retry could make the step not idempotent
+                    //
+                    return stepResultFromHookResult(hookResult);
+                } else if (hookResult != null && ResultAction.COMPLETE.equals(hookResult.getAction())) {
+                    log.info("Activity {} returned result {} ({}) but a post-step hook forced a success ({}).",
+                            activityName, result.getResultCode(), result.getMessage(),
+                            hookResult.getMessage());
+
+                    //
+                    // On a complete we would like to preserve all the attributes the step returned
+                    //
+                    return stepResultFromHookResult(hookResult)
+                        .withAttributes(result.getAttributes());
                 }
+            }
+
+            if (result.getAction() != StepResult.ResultAction.RETRY) {
+                //
+                // Only attach the extra attributes the step hooks added
+                // if the result was not a retry. Preserving attributes
+                // across retries could cause hooks to not be idempotent.
+                //
+                result.withAttributes(attributes.extraAttributes());
             }
 
             return result;
@@ -130,6 +161,10 @@ public final class ActivityExecutionUtil {
             log.error("Caught an exception while executing activity task", e);
             throw e;
         }
+    }
+
+    private static StepResult stepResultFromHookResult(HookResult hookResult) {
+        return new StepResult(hookResult.getAction(), hookResult.getResultCode(), hookResult.getMessage());
     }
 
     // public for test visibility

--- a/flux-common/src/main/java/com/danielgmyers/flux/step/internal/ExecutionAttributes.java
+++ b/flux-common/src/main/java/com/danielgmyers/flux/step/internal/ExecutionAttributes.java
@@ -1,0 +1,62 @@
+/*
+ *   Copyright Flux Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.danielgmyers.flux.step.internal;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.danielgmyers.flux.step.StepInputAccessor;
+
+/**
+ * Wrapper around {@link StepInputAccessor} that also contains an extra bag of properties
+ * that can be overridden by step hooks. Used to allow hooks to attach extra attributes
+ * when intercepting workflow steps.
+ *
+ * Extra attributes added to this collection will override existing attributes
+ * provided by the delegate.
+ */
+public final class ExecutionAttributes implements StepInputAccessor {
+    private final StepInputAccessor delegate;
+    private final Map<String, Object> extra;
+
+    public ExecutionAttributes(StepInputAccessor delegate) {
+        this.delegate = delegate;
+        this.extra = new HashMap<>();
+    }
+
+    @Override
+    public <T> T getAttribute(Class<T> requestedType, String attributeName) {
+        Object value = extra.get(attributeName);
+        if (value != null && requestedType.isAssignableFrom(value.getClass())) {
+            return (T)value;
+        }
+
+        return delegate.getAttribute(requestedType, attributeName);
+    }
+
+    public void putExtraAttribute(String key, Object value) {
+        extra.put(key, value);
+    }
+
+    public void putExtraAttributes(Map<String, Object> values) {
+        extra.putAll(values);
+    }
+
+    public Map<String, Object> extraAttributes() {
+        return extra;
+    }
+}

--- a/flux-common/src/main/java/com/danielgmyers/flux/step/internal/WorkflowStepUtil.java
+++ b/flux-common/src/main/java/com/danielgmyers/flux/step/internal/WorkflowStepUtil.java
@@ -29,12 +29,14 @@ import java.util.stream.Collectors;
 import com.danielgmyers.flux.ex.AttributeTypeMismatchException;
 import com.danielgmyers.flux.poller.TaskNaming;
 import com.danielgmyers.flux.step.Attribute;
+import com.danielgmyers.flux.step.HookResult;
 import com.danielgmyers.flux.step.PartitionIdGenerator;
 import com.danielgmyers.flux.step.PartitionIdGeneratorResult;
 import com.danielgmyers.flux.step.PartitionedWorkflowStep;
 import com.danielgmyers.flux.step.StepHook;
 import com.danielgmyers.flux.step.StepInputAccessor;
 import com.danielgmyers.flux.step.StepResult;
+import com.danielgmyers.flux.step.StepResult.ResultAction;
 import com.danielgmyers.flux.step.WorkflowStep;
 import com.danielgmyers.flux.step.WorkflowStepHook;
 import com.danielgmyers.flux.wf.Workflow;
@@ -179,12 +181,15 @@ public final class WorkflowStepUtil {
 
     /**
      * Executes a set of step hooks with the specified input attributes, for any hooks whose type matches the specified hook type.
-     * Returns null unless the step should be retried due to a hook failure.
+     * Returns null unless the step result has been overridden by a step hook.
      */
-    public static StepResult executeHooks(List<WorkflowStepHook> hooks, StepInputAccessor stepInput,
+    public static HookResult executeHooks(List<WorkflowStepHook> hooks, ExecutionAttributes attributes,
                                           Map<String, Object> specialHookInputs, StepHook.HookType hookType,
                                           String activityName, MetricRecorder fluxMetrics, MetricRecorder hookMetrics,
                                           Workflow workflow, WorkflowStep step) {
+
+        HookResult effectiveResult = null;
+
         for (WorkflowStepHook hook : hooks) {
             Map<Method, StepHook> methods = WorkflowStepUtil.getAllMethodsWithAnnotation(hook.getClass(), StepHook.class);
             for (Map.Entry<Method, StepHook> method : methods.entrySet()) {
@@ -200,11 +205,37 @@ public final class WorkflowStepUtil {
                                                                                                     step,
                                                                                                     method.getKey(),
                                                                                                     hookMetrics,
-                                                                                                    stepInput,
+                                                                                                    attributes,
                                                                                                     specialHookInputs));
                     if (result != null) {
                         log.info("Hook {} for activity {} returned value: {}",
                                                hook.getClass().getSimpleName(), activityName, result);
+                    }
+
+                    if (result instanceof HookResult) {
+                        HookResult hookResult = (HookResult) result;
+                        ResultAction action = hookResult.getAction();
+                        if (action == null) {
+                            //
+                            // If we should continue add any new attributes to the resulting attribute bag
+                            //
+                            attributes.putExtraAttributes(hookResult.getAttributes());
+                        } else if (action.equals(ResultAction.RETRY)) {
+                            //
+                            // Don't carry attributes over on a retry
+                            //
+                            effectiveResult = hookResult;
+                        } else if (action.equals(ResultAction.COMPLETE)) {
+                            //
+                            // For success responses we merge the attributes of the current result
+                            // and the new step result.
+                            //
+                            if (effectiveResult == null) {
+                                effectiveResult = hookResult;
+                            } else if (effectiveResult.getAction().equals(ResultAction.COMPLETE)) {
+                                effectiveResult = effectiveResult.withAllAttributes(hookResult.getAttributes());
+                            }
+                        }
                     }
                 } catch (InvocationTargetException e) {
                     String message = String.format("Hook %s for activity %s threw an exception (%s)",
@@ -212,7 +243,7 @@ public final class WorkflowStepUtil {
                     if (method.getValue().retryOnFailure()) {
                         message += ", and the hook is configured to retry on failure.";
                         log.info(message, e.getCause());
-                        return StepResult.retry(message);
+                        return HookResult.retry(message);
                     } else {
                         log.info("{}, but the hook is configured to ignore failures.", message, e.getCause());
                     }
@@ -224,7 +255,7 @@ public final class WorkflowStepUtil {
                     if (method.getValue().retryOnFailure()) {
                         message += ", and the hook is configured to retry on failure.";
                         log.error(message, e.getCause());
-                        return StepResult.retry(message);
+                        return HookResult.retry(message);
                     } else {
                         log.error("{}, but the hook is configured to ignore failures.", message, e.getCause());
                     }
@@ -233,7 +264,7 @@ public final class WorkflowStepUtil {
                 }
             }
         }
-        return null;
+        return effectiveResult;
     }
 
     // public only for testing visibility

--- a/flux-common/src/test/java/com/danielgmyers/flux/step/internal/ActivityExecutionUtilTest.java
+++ b/flux-common/src/test/java/com/danielgmyers/flux/step/internal/ActivityExecutionUtilTest.java
@@ -25,6 +25,7 @@ import com.danielgmyers.flux.step.Attribute;
 import com.danielgmyers.flux.step.StepApply;
 import com.danielgmyers.flux.step.StepAttributes;
 import com.danielgmyers.flux.step.StepHook;
+import com.danielgmyers.flux.step.HookResult;
 import com.danielgmyers.flux.step.StepInputAccessor;
 import com.danielgmyers.flux.step.StepResult;
 import com.danielgmyers.flux.step.WorkflowStep;
@@ -536,6 +537,43 @@ public class ActivityExecutionUtilTest {
                 result.getResultCode())).intValue());
     }
 
+    @Test
+    public void testExecuteHooksAndActivity_hooksCanAddExtraAttributesOnSuccess() {
+        var testStep = new TestInputStep();
+        WorkflowGraphBuilder builder = new WorkflowGraphBuilder(testStep);
+        builder.alwaysClose(testStep);
+        builder.addStepHook(testStep, new TestHookAttachAttributes());
+
+        Workflow workflow = new TestWorkflow(builder.build());
+
+        StepResult result = ActivityExecutionUtil.executeHooksAndActivity(workflow, testStep, emptyInput, fluxMetrics, stepMetrics);
+        Assertions.assertEquals(StepResult.ResultAction.COMPLETE, result.getAction());
+
+        fluxMetrics.close();
+
+        Assertions.assertEquals(TestHookAttachAttributes.TRACE_ID, result.getAttributes().get(StepWithSeveralInputs.STRING_PARAM));
+    }
+
+    @Test
+    public void testExecuteHooksAndActivity_attributesAddedByHooksAreDiscardedOnRetry() {
+        var testStep = new TestInputStep();
+        RuntimeException e = new RuntimeException("Wheeee!");
+        testStep.setExceptionToThrow(e);
+
+        WorkflowGraphBuilder builder = new WorkflowGraphBuilder(testStep);
+        builder.alwaysClose(testStep);
+        builder.addStepHook(testStep, new TestHookAttachAttributes());
+
+        Workflow workflow = new TestWorkflow(builder.build());
+
+        StepResult result = ActivityExecutionUtil.executeHooksAndActivity(workflow, testStep, emptyInput, fluxMetrics, stepMetrics);
+        Assertions.assertEquals(StepResult.ResultAction.RETRY, result.getAction());
+
+        fluxMetrics.close();
+
+        Assertions.assertFalse(result.getAttributes().containsKey(StepWithSeveralInputs.STRING_PARAM));
+    }
+
     private StepResult makeStepResult(StepResult.ResultAction resultAction, String stepResult, String message, Map<String, Object> output) {
         return new StepResult(resultAction, stepResult, message).withAttributes(output);
     }
@@ -740,6 +778,51 @@ public class ActivityExecutionUtilTest {
         }
     }
 
+    public static class TestHookAttachAttributes implements WorkflowStepHook {
+        public static final String TRACE_ID = "fuddle-abcd-1234-000";
+
+        TestHookAttachAttributes() {
+
+        }
+
+        @StepHook(hookType = StepHook.HookType.PRE)
+        public HookResult preStepHook(Workflow workflow, WorkflowStep step) {
+            return HookResult.proceed()
+                .withAttribute("MyWorkflowName", workflow.getClass().getSimpleName())
+                .withAttribute("MyStepName", step.getClass().getSimpleName())
+                .withAllAttributes(Map.of(StepWithSeveralInputs.STRING_PARAM, TestHookAttachAttributes.TRACE_ID));
+        }
+
+        @StepHook(hookType = StepHook.HookType.POST)
+        public void postStepHook(@Attribute("MyWorkflowName") String workflowName,
+                                 @Attribute("MyStepName") String stepName,
+                                 @Attribute(StepWithSeveralInputs.STRING_PARAM) String traceId,
+                                 Workflow workflow,
+                                 WorkflowStep step) {
+
+            Assertions.assertEquals(workflow.getClass().getSimpleName(), workflowName);
+            Assertions.assertEquals(step.getClass().getSimpleName(), stepName);
+            Assertions.assertEquals(TRACE_ID, traceId);
+        }
+    }
+
+    public static class TestInputStep implements WorkflowStep {
+        private RuntimeException exceptionToThrow = null;
+
+        public void setExceptionToThrow(RuntimeException exceptionToThrow) {
+            this.exceptionToThrow = exceptionToThrow;
+        }
+
+        @StepApply
+        public StepResult apply(@Attribute(StepWithSeveralInputs.STRING_PARAM) String traceId) {
+            Assertions.assertEquals(TestHookAttachAttributes.TRACE_ID, traceId);
+            if (exceptionToThrow != null) {
+                throw exceptionToThrow;
+            }
+            return StepResult.success();
+        }
+    }
+
     public static class TestPreHookThrowsExceptionNoRetryOnFailure implements WorkflowStepHook {
         private final Throwable ex;
 
@@ -790,5 +873,135 @@ public class ActivityExecutionUtilTest {
         public void postStepHook() throws Throwable {
             throw ex;
         }
+    }
+
+    @Test
+    public void testPreHookRetryWinsOverComplete() {
+        WorkflowStepHook retryHook = new WorkflowStepHook() {
+            @StepHook(hookType = StepHook.HookType.PRE)
+            public HookResult pre() {
+                return HookResult.retry("pre-retry");
+            }
+        };
+
+        WorkflowStepHook completeHook = new WorkflowStepHook() {
+            @StepHook(hookType = StepHook.HookType.PRE)
+            public HookResult pre() {
+                return HookResult.complete(StepResult.SUCCEED_RESULT_CODE, "pre-complete");
+            }
+        };
+
+        WorkflowGraphBuilder builder = new WorkflowGraphBuilder(step);
+        builder.alwaysClose(step);
+        builder.addStepHook(step, retryHook);
+        builder.addStepHook(step, completeHook);
+
+        Workflow workflow = new TestWorkflow(builder.build());
+
+        StepResult result = ActivityExecutionUtil.executeHooksAndActivity(workflow, step, emptyInput, fluxMetrics, stepMetrics);
+        Assertions.assertEquals(StepResult.ResultAction.RETRY, result.getAction());
+    }
+
+    @Test
+    public void testMultipleCompleteHooksContributeAttributes() {
+        // Hook execution order is indeterminate, but both hooks WILL execute
+        // Each hook adds a unique attribute key, so we can verify both contributed
+        WorkflowStepHook first = new WorkflowStepHook() {
+            @StepHook(hookType = StepHook.HookType.POST)
+            public HookResult post() {
+                return HookResult.complete(StepResult.SUCCEED_RESULT_CODE, "first").withAttribute("attr1", "value1");
+            }
+        };
+
+        WorkflowStepHook second = new WorkflowStepHook() {
+            @StepHook(hookType = StepHook.HookType.POST)
+            public HookResult post() {
+                return HookResult.complete(StepResult.SUCCEED_RESULT_CODE, "second").withAttribute("attr2", "value2");
+            }
+        };
+
+        WorkflowGraphBuilder builder = new WorkflowGraphBuilder(step);
+        builder.alwaysClose(step);
+        builder.addStepHook(step, first);
+        builder.addStepHook(step, second);
+
+        Workflow workflow = new TestWorkflow(builder.build());
+
+        Map<String, Object> output = Collections.emptyMap();
+        StepResult stepResult = makeStepResult(StepResult.ResultAction.COMPLETE, StepResult.SUCCEED_RESULT_CODE, "yay", output);
+        step.setStepResult(stepResult);
+
+        StepResult result = ActivityExecutionUtil.executeHooksAndActivity(workflow, step, emptyInput, fluxMetrics, stepMetrics);
+
+        // Both hooks execute in indeterminate order, so both attribute keys must be present
+        Assertions.assertEquals(StepResult.ResultAction.COMPLETE, result.getAction());
+        Assertions.assertTrue(result.getAttributes().containsKey("attr1"), "Hook 1 should have contributed attr1");
+        Assertions.assertTrue(result.getAttributes().containsKey("attr2"), "Hook 2 should have contributed attr2");
+    }
+
+    @Test
+    public void testPostHookCanOverrideRetryWithComplete() {
+        // step throws exception -> initial retry
+        RuntimeException e = new RuntimeException("boom");
+        step.setExceptionToThrow(e);
+
+        WorkflowStepHook postComplete = new WorkflowStepHook() {
+            @StepHook(hookType = StepHook.HookType.POST)
+            public HookResult post() {
+                return HookResult.complete(StepResult.SUCCEED_RESULT_CODE, "post-complete").withAttribute("x", "y");
+            }
+        };
+
+        WorkflowGraphBuilder builder = new WorkflowGraphBuilder(step);
+        builder.alwaysClose(step);
+        builder.addStepHook(step, postComplete);
+
+        Workflow workflow = new TestWorkflow(builder.build());
+
+        StepResult result = ActivityExecutionUtil.executeHooksAndActivity(workflow, step, emptyInput, fluxMetrics, stepMetrics);
+        Assertions.assertEquals(StepResult.ResultAction.COMPLETE, result.getAction());
+        Assertions.assertEquals("y", result.getAttributes().get("x"));
+    }
+
+    @Test
+    public void testMultiplePreHooksContributeAttributes() {
+        // Hook execution order is indeterminate, so use unique attribute keys to avoid conflicts
+        WorkflowStepHook first = new WorkflowStepHook() {
+            @StepHook(hookType = StepHook.HookType.PRE)
+            public HookResult pre() {
+                return HookResult.proceed().withAttribute("attr1", "value1");
+            }
+        };
+
+        WorkflowStepHook second = new WorkflowStepHook() {
+            @StepHook(hookType = StepHook.HookType.PRE)
+            public HookResult pre() {
+                return HookResult.proceed().withAttribute("attr2", "value2");
+            }
+        };
+
+        class MultiAttrStep implements WorkflowStep {
+            @StepApply
+            public StepResult apply(@Attribute("attr1") String attr1, @Attribute("attr2") String attr2) {
+                // Both PRE hooks should have executed and contributed their attributes
+                Assertions.assertNotNull(attr1);
+                Assertions.assertNotNull(attr2);
+                return StepResult.success();
+            }
+        }
+
+        MultiAttrStep testStep = new MultiAttrStep();
+        WorkflowGraphBuilder builder = new WorkflowGraphBuilder(testStep);
+        builder.alwaysClose(testStep);
+        builder.addStepHook(testStep, first);
+        builder.addStepHook(testStep, second);
+
+        Workflow workflow = new TestWorkflow(builder.build());
+
+        StepResult result = ActivityExecutionUtil.executeHooksAndActivity(workflow, testStep, emptyInput, fluxMetrics, stepMetrics);
+        Assertions.assertEquals(StepResult.ResultAction.COMPLETE, result.getAction());
+        // Both hooks execute in indeterminate order, so both attribute keys must be present
+        Assertions.assertTrue(result.getAttributes().containsKey("attr1"));
+        Assertions.assertTrue(result.getAttributes().containsKey("attr2"));
     }
 }


### PR DESCRIPTION
Resolves #170 and #151. This adds support for both adding extra attributes to a workflow inside a step hook and overriding the resultCode and message of a workflow step from inside a hook