### PR TITLE
[#151] Add step hook result overriding

### DIFF
--- a/flux-common/src/main/java/com/danielgmyers/flux/step/HookResult.java
+++ b/flux-common/src/main/java/com/danielgmyers/flux/step/HookResult.java
@@ -1,0 +1,114 @@
+/*
+ *   Copyright Flux Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.danielgmyers.flux.step;
+
+import java.util.Objects;
+
+/**
+ * Allows a step or workflow hook to modify the execution of a step. Can be returned by
+ * a {@link StepHook} annotated method.
+ *
+ * Step and workflow hooks are executed in the order they are added. Hook actions
+ * are evaluated with the first non-proceed result being the final result. All hooks
+ * are evaluated for each step execution and results after a non-proceed result are
+ * discarded.
+ */
+public final class HookResult {
+    private enum HookAction {
+        CONTINUE,
+        RETRY,
+        FORCE_RESULT
+    }
+
+    private final HookAction action;
+    private final String resultCode;
+    private final String message;
+
+    /**
+     * Continue execution of the step as normal.
+     * @return a HookResult instructing Flux to continue normal execution
+     */
+    public static HookResult proceed() {
+        return new HookResult(HookAction.CONTINUE, null, null);
+    }
+
+    /**
+     * Force the step to be retried.
+     *
+     * If this is returned from a PRE hook all remaining PRE step hooks are executed, the
+     * step body is skipped, and then all POST step hooks are executed. The step is
+     * then scheduled for a retry.
+     *
+     * If this is returned from a POST hook all remaining POST step hooks are executed,
+     * and the step is then scheduled for a retry.
+     * @return a HookResult instructing Flux to retry the step
+     */
+    public static HookResult retryStep() {
+        return retryStep(null);
+    }
+
+    public static HookResult retryStep(String message) {
+        return new HookResult(HookAction.RETRY, null, message);
+    }
+
+    /**
+     * Ignore the steps result and override it with a new result.
+     *
+     * If this is returned from a PRE hook all remaining PRE step hooks are executed,
+     * the step body is skipped, and then all POST step hooks are executed. The steps
+     * result is then recorded as this result.
+     *
+     * If this is returned from a POST hook all remaining POST step hooks are executed,
+     * and the steps result is then replaced with this value.
+     *
+     * @param resultCode the result code to record for the step
+     * @return a HookResult instructing Flux to override the step's result
+     */
+    public static HookResult overrideStepResult(String resultCode) {
+        return overrideStepResult(resultCode, null);
+    }
+
+    public static HookResult overrideStepResult(String resultCode, String message) {
+        return new HookResult(HookAction.FORCE_RESULT, Objects.requireNonNull(resultCode), message);
+    }
+
+    private HookResult(HookAction action, String resultCode, String message) {
+        this.action = Objects.requireNonNull(action);
+        this.resultCode = resultCode;
+        this.message = message;
+    }
+
+    public boolean isContinue() {
+        return action.equals(HookAction.CONTINUE);
+    }
+
+    public boolean isRetry() {
+        return action.equals(HookAction.RETRY);
+    }
+
+    public boolean isForceResult() {
+        return action.equals(HookAction.FORCE_RESULT);
+    }
+
+    public String getResultCode() {
+        return resultCode;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/flux-common/src/main/java/com/danielgmyers/flux/step/internal/ActivityExecutionUtil.java
+++ b/flux-common/src/main/java/com/danielgmyers/flux/step/internal/ActivityExecutionUtil.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.danielgmyers.flux.poller.TaskNaming;
+import com.danielgmyers.flux.step.HookResult;
 import com.danielgmyers.flux.step.StepApply;
 import com.danielgmyers.flux.step.StepAttributes;
 import com.danielgmyers.flux.step.StepHook;
@@ -93,33 +94,58 @@ public final class ActivityExecutionUtil {
             Map<String, Object> hookInput = new HashMap<>();
             hookInput.put(StepAttributes.ACTIVITY_NAME, StepAttributes.encode(activityName));
 
+            // Hooks on the workflow hook anchor steps run for their side effects only;
+            // they cannot override the anchor's result, so we discard any HookResult they return.
+            boolean isWorkflowHookAnchor = (step.getClass() == PreWorkflowHookAnchor.class
+                                            || step.getClass() == PostWorkflowHookAnchor.class);
+
             StepResult result = null;
             if (hooks != null && step.getClass() != PostWorkflowHookAnchor.class) {
-                result = WorkflowStepUtil.executeHooks(hooks, stepInput, hookInput, StepHook.HookType.PRE, activityName,
-                        fluxMetrics, stepMetrics, workflow, step);
+                HookResult hookResult = WorkflowStepUtil.executeHooks(hooks, stepInput, hookInput, StepHook.HookType.PRE,
+                        activityName, fluxMetrics, stepMetrics, workflow, step);
+                if (hookResult != null) {
+                    if (isWorkflowHookAnchor) {
+                        log.warn("Cannot override the result of a workflow hook ({})",
+                                hookResult.getMessage());
+                    } else {
+                        result = hookResultToStepResult(hookResult);
+                    }
+                }
             }
+
+            // Did the pre-step hooks override the result of the step
+            boolean preHookOverride = result != null;
 
             if (result == null) {
                 result = executeActivity(step, activityName, fluxMetrics, stepMetrics, stepInput, workflow);
 
                 hookInput.putAll(result.getAttributes());
+            }
 
-                // retries put their reason message in the special ActivityTaskFailed reason field.
-                if (result.getAction() != StepResult.ResultAction.RETRY && result.getMessage() != null) {
-                    hookInput.put(StepAttributes.ACTIVITY_COMPLETION_MESSAGE, result.getMessage());
-                }
-                if (result.getResultCode() != null) {
-                    hookInput.put(StepAttributes.RESULT_CODE, result.getResultCode());
-                }
+            // retries put their reason message in the special ActivityTaskFailed reason field.
+            if (result.getAction() != StepResult.ResultAction.RETRY && result.getMessage() != null) {
+                hookInput.put(StepAttributes.ACTIVITY_COMPLETION_MESSAGE, result.getMessage());
+            }
+            if (result.getResultCode() != null) {
+                hookInput.put(StepAttributes.RESULT_CODE, result.getResultCode());
+            }
 
-                if (hooks != null && step.getClass() != PreWorkflowHookAnchor.class) {
-                    StepResult hookResult = WorkflowStepUtil.executeHooks(hooks, stepInput, hookInput, StepHook.HookType.POST,
-                            activityName, fluxMetrics, stepMetrics, workflow, step);
-                    if (hookResult != null) {
-                        log.info("Activity {} returned result {} ({}) but a post-step hook requires a retry ({}).",
-                                activityName, result.getResultCode(), result.getMessage(),
+            if (hooks != null && step.getClass() != PreWorkflowHookAnchor.class) {
+                HookResult hookResult = WorkflowStepUtil.executeHooks(hooks, stepInput, hookInput, StepHook.HookType.POST,
+                        activityName, fluxMetrics, stepMetrics, workflow, step);
+
+                if (hookResult != null) {
+                    if (isWorkflowHookAnchor) {
+                        log.warn("Cannot override the result of a workflow hook {} ({})",
+                                 hookResult.getResultCode(), hookResult.getMessage());
+                    } else {
+                        log.info("Activity {} returned result {} ({}) but a post-step hook replaced the result with {} ({}).",
+                                activityName, result.getResultCode(), result.getMessage(), hookResult.getResultCode(),
                                 hookResult.getMessage());
-                        return hookResult;
+
+                        if (!preHookOverride) {
+                            result = hookResultToStepResult(hookResult);
+                        }
                     }
                 }
             }
@@ -130,6 +156,14 @@ public final class ActivityExecutionUtil {
             log.error("Caught an exception while executing activity task", e);
             throw e;
         }
+    }
+
+    private static StepResult hookResultToStepResult(HookResult hookResult) {
+        if (hookResult.isRetry()) {
+            return StepResult.retry(hookResult.getMessage());
+        }
+
+        return StepResult.complete(hookResult.getResultCode(), hookResult.getMessage());
     }
 
     // public for test visibility

--- a/flux-common/src/main/java/com/danielgmyers/flux/step/internal/WorkflowStepUtil.java
+++ b/flux-common/src/main/java/com/danielgmyers/flux/step/internal/WorkflowStepUtil.java
@@ -29,6 +29,7 @@ import java.util.stream.Collectors;
 import com.danielgmyers.flux.ex.AttributeTypeMismatchException;
 import com.danielgmyers.flux.poller.TaskNaming;
 import com.danielgmyers.flux.step.Attribute;
+import com.danielgmyers.flux.step.HookResult;
 import com.danielgmyers.flux.step.PartitionIdGenerator;
 import com.danielgmyers.flux.step.PartitionIdGeneratorResult;
 import com.danielgmyers.flux.step.PartitionedWorkflowStep;
@@ -181,16 +182,19 @@ public final class WorkflowStepUtil {
      * Executes a set of step hooks with the specified input attributes, for any hooks whose type matches the specified hook type.
      * Returns null unless the step should be retried due to a hook failure.
      */
-    public static StepResult executeHooks(List<WorkflowStepHook> hooks, StepInputAccessor stepInput,
+    public static HookResult executeHooks(List<WorkflowStepHook> hooks, StepInputAccessor stepInput,
                                           Map<String, Object> specialHookInputs, StepHook.HookType hookType,
                                           String activityName, MetricRecorder fluxMetrics, MetricRecorder hookMetrics,
                                           Workflow workflow, WorkflowStep step) {
+
+        HookResult finalResult = null;
         for (WorkflowStepHook hook : hooks) {
             Map<Method, StepHook> methods = WorkflowStepUtil.getAllMethodsWithAnnotation(hook.getClass(), StepHook.class);
             for (Map.Entry<Method, StepHook> method : methods.entrySet()) {
                 if (method.getValue().hookType() != hookType) {
                     continue;
                 }
+
                 String hookExecutionTimeMetricName = formatHookExecutionTimeName(hook.getClass().getSimpleName(),
                                                         method.getKey().getName(), activityName);
                 fluxMetrics.startDuration(hookExecutionTimeMetricName);
@@ -205,6 +209,15 @@ public final class WorkflowStepUtil {
                     if (result != null) {
                         log.info("Hook {} for activity {} returned value: {}",
                                                hook.getClass().getSimpleName(), activityName, result);
+
+                        if (result instanceof HookResult && finalResult == null) {
+                            HookResult hookResult = (HookResult) result;
+                            if (hookResult.isForceResult()) {
+                                finalResult = HookResult.overrideStepResult(hookResult.getResultCode(), hookResult.getMessage());
+                            } else if (hookResult.isRetry()) {
+                                finalResult = HookResult.retryStep(hookResult.getMessage());
+                            }
+                        }
                     }
                 } catch (InvocationTargetException e) {
                     String message = String.format("Hook %s for activity %s threw an exception (%s)",
@@ -212,7 +225,9 @@ public final class WorkflowStepUtil {
                     if (method.getValue().retryOnFailure()) {
                         message += ", and the hook is configured to retry on failure.";
                         log.info(message, e.getCause());
-                        return StepResult.retry(message);
+                        if (finalResult == null) {
+                            finalResult = HookResult.retryStep(message);
+                        }
                     } else {
                         log.info("{}, but the hook is configured to ignore failures.", message, e.getCause());
                     }
@@ -224,7 +239,9 @@ public final class WorkflowStepUtil {
                     if (method.getValue().retryOnFailure()) {
                         message += ", and the hook is configured to retry on failure.";
                         log.error(message, e.getCause());
-                        return StepResult.retry(message);
+                        if (finalResult == null) {
+                            finalResult = HookResult.retryStep(message);
+                        }
                     } else {
                         log.error("{}, but the hook is configured to ignore failures.", message, e.getCause());
                     }
@@ -233,7 +250,8 @@ public final class WorkflowStepUtil {
                 }
             }
         }
-        return null;
+
+        return finalResult;
     }
 
     // public only for testing visibility

--- a/flux-common/src/test/java/com/danielgmyers/flux/step/HookResultTest.java
+++ b/flux-common/src/test/java/com/danielgmyers/flux/step/HookResultTest.java
@@ -1,0 +1,84 @@
+/*
+ *   Copyright Flux Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.danielgmyers.flux.step;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class HookResultTest {
+
+    @Test
+    public void proceed_isContinueAction() {
+        HookResult result = HookResult.proceed();
+
+        Assertions.assertTrue(result.isContinue());
+        Assertions.assertFalse(result.isRetry());
+        Assertions.assertFalse(result.isForceResult());
+        Assertions.assertNull(result.getResultCode());
+        Assertions.assertNull(result.getMessage());
+    }
+
+    @Test
+    public void retryStep_noMessage_isRetryActionWithNullMessage() {
+        HookResult result = HookResult.retryStep();
+
+        Assertions.assertFalse(result.isContinue());
+        Assertions.assertTrue(result.isRetry());
+        Assertions.assertFalse(result.isForceResult());
+        Assertions.assertNull(result.getResultCode());
+        Assertions.assertNull(result.getMessage());
+    }
+
+    @Test
+    public void retryStep_withMessage_isRetryActionWithMessage() {
+        HookResult result = HookResult.retryStep("please retry");
+
+        Assertions.assertFalse(result.isContinue());
+        Assertions.assertTrue(result.isRetry());
+        Assertions.assertFalse(result.isForceResult());
+        Assertions.assertNull(result.getResultCode());
+        Assertions.assertEquals("please retry", result.getMessage());
+    }
+
+    @Test
+    public void overrideStepResult_codeOnly_isForceResultActionWithNullMessage() {
+        HookResult result = HookResult.overrideStepResult("forced");
+
+        Assertions.assertFalse(result.isContinue());
+        Assertions.assertFalse(result.isRetry());
+        Assertions.assertTrue(result.isForceResult());
+        Assertions.assertEquals("forced", result.getResultCode());
+        Assertions.assertNull(result.getMessage());
+    }
+
+    @Test
+    public void overrideStepResult_codeAndMessage_isForceResultActionWithMessage() {
+        HookResult result = HookResult.overrideStepResult("forced", "because reasons");
+
+        Assertions.assertFalse(result.isContinue());
+        Assertions.assertFalse(result.isRetry());
+        Assertions.assertTrue(result.isForceResult());
+        Assertions.assertEquals("forced", result.getResultCode());
+        Assertions.assertEquals("because reasons", result.getMessage());
+    }
+
+    @Test
+    public void overrideStepResult_nullCode_throwsNullPointerException() {
+        Assertions.assertThrows(NullPointerException.class, () -> HookResult.overrideStepResult(null));
+        Assertions.assertThrows(NullPointerException.class, () -> HookResult.overrideStepResult(null, "msg"));
+    }
+}

--- a/flux-common/src/test/java/com/danielgmyers/flux/step/internal/ActivityExecutionUtilTest.java
+++ b/flux-common/src/test/java/com/danielgmyers/flux/step/internal/ActivityExecutionUtilTest.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 import com.danielgmyers.flux.poller.TaskNaming;
 import com.danielgmyers.flux.step.Attribute;
+import com.danielgmyers.flux.step.HookResult;
 import com.danielgmyers.flux.step.StepApply;
 import com.danielgmyers.flux.step.StepAttributes;
 import com.danielgmyers.flux.step.StepHook;
@@ -536,6 +537,385 @@ public class ActivityExecutionUtilTest {
                 result.getResultCode())).intValue());
     }
 
+    @Test
+    public void testExecuteHooksAndActivity_preHookProceed_doesNotAlterStepResult() {
+        TestPreHookReturningHookResult preHook = new TestPreHookReturningHookResult(HookResult.proceed());
+        Workflow workflow = workflowWithStepHooks(preHook);
+
+        StepResult expectedResult = successfulStepResult();
+        step.setStepResult(expectedResult);
+
+        StepResult actualResult = ActivityExecutionUtil.executeHooksAndActivity(workflow, step, emptyInput, fluxMetrics, stepMetrics);
+
+        Assertions.assertTrue(step.didThing());
+        Assertions.assertEquals(1, preHook.getInvocationCount());
+        Assertions.assertEquals(expectedResult, actualResult);
+
+        fluxMetrics.close();
+        Assertions.assertEquals(1, fluxMetrics.getCounts().get(ActivityExecutionUtil.formatCompletionResultMetricName(TaskNaming.activityName(workflow, step),
+                StepResult.SUCCEED_RESULT_CODE)).intValue());
+    }
+
+    @Test
+    public void testExecuteHooksAndActivity_preHookRetry_skipsStepBody_runsPostHooks_returnsRetry() {
+        TestPreHookReturningHookResult preHook = new TestPreHookReturningHookResult(HookResult.retryStep("pre says retry"));
+        TestPostStepHook postHook = new TestPostStepHook();
+        Workflow workflow = workflowWithStepHooks(preHook, postHook);
+        step.setStepResult(successfulStepResult());
+
+        StepResult actualResult = ActivityExecutionUtil.executeHooksAndActivity(workflow, step, emptyInput, fluxMetrics, stepMetrics);
+
+        Assertions.assertFalse(step.didThing(), "step body must be skipped when pre-hook returns a non-proceed HookResult");
+        Assertions.assertEquals(1, preHook.getInvocationCount());
+        Assertions.assertEquals(1, postHook.getPostStepHookCallCount(), "post hooks must still run when a pre-hook overrides the result");
+        assertRetryResult(actualResult, "pre says retry");
+    }
+
+    @Test
+    public void testExecuteHooksAndActivity_preHookForceResult_skipsStepBody_runsPostHooks_returnsForcedResult() {
+        TestPreHookReturningHookResult preHook = new TestPreHookReturningHookResult(HookResult.overrideStepResult("FORCED", "forced from pre"));
+        TestPostStepHook postHook = new TestPostStepHook();
+        Workflow workflow = workflowWithStepHooks(preHook, postHook);
+        step.setStepResult(successfulStepResult());
+
+        StepResult actualResult = ActivityExecutionUtil.executeHooksAndActivity(workflow, step, emptyInput, fluxMetrics, stepMetrics);
+
+        Assertions.assertFalse(step.didThing(), "step body must be skipped when pre-hook forces a result");
+        Assertions.assertEquals(1, preHook.getInvocationCount());
+        Assertions.assertEquals(1, postHook.getPostStepHookCallCount());
+        assertCompleteResult(actualResult, "FORCED", "forced from pre");
+    }
+
+    @Test
+    public void testExecuteHooksAndActivity_postHookRetry_overridesSuccessfulStepResult() {
+        TestPostHookReturningHookResult postHook = new TestPostHookReturningHookResult(HookResult.retryStep("post says retry"));
+        Workflow workflow = workflowWithStepHooks(postHook);
+        step.setStepResult(successfulStepResult());
+
+        StepResult actualResult = ActivityExecutionUtil.executeHooksAndActivity(workflow, step, emptyInput, fluxMetrics, stepMetrics);
+
+        Assertions.assertTrue(step.didThing());
+        Assertions.assertEquals(1, postHook.getInvocationCount());
+        assertRetryResult(actualResult, "post says retry");
+    }
+
+    @Test
+    public void testExecuteHooksAndActivity_postHookForceResult_overridesSuccessfulStepResult() {
+        TestPostHookReturningHookResult postHook = new TestPostHookReturningHookResult(HookResult.overrideStepResult("FORCED", "forced from post"));
+        Workflow workflow = workflowWithStepHooks(postHook);
+        step.setStepResult(successfulStepResult());
+
+        StepResult actualResult = ActivityExecutionUtil.executeHooksAndActivity(workflow, step, emptyInput, fluxMetrics, stepMetrics);
+
+        Assertions.assertTrue(step.didThing());
+        Assertions.assertEquals(1, postHook.getInvocationCount());
+        assertCompleteResult(actualResult, "FORCED", "forced from post");
+    }
+
+    @Test
+    public void testExecuteHooksAndActivity_postHookProceed_doesNotAlterStepResult() {
+        TestPostHookReturningHookResult postHook = new TestPostHookReturningHookResult(HookResult.proceed());
+        Workflow workflow = workflowWithStepHooks(postHook);
+
+        StepResult expected = successfulStepResult();
+        step.setStepResult(expected);
+
+        StepResult actualResult = ActivityExecutionUtil.executeHooksAndActivity(workflow, step, emptyInput, fluxMetrics, stepMetrics);
+
+        Assertions.assertEquals(expected, actualResult);
+        Assertions.assertEquals(1, postHook.getInvocationCount());
+    }
+
+    @Test
+    public void testExecuteHooksAndActivity_preHookForceResult_winsOverPostHookForceResult() {
+        TestPreHookReturningHookResult preHook = new TestPreHookReturningHookResult(HookResult.overrideStepResult("PRE_FORCED", "pre forced"));
+        TestPostHookReturningHookResult postHook = new TestPostHookReturningHookResult(HookResult.overrideStepResult("POST_FORCED", "post forced"));
+        Workflow workflow = workflowWithStepHooks(preHook, postHook);
+        step.setStepResult(successfulStepResult());
+
+        StepResult actualResult = ActivityExecutionUtil.executeHooksAndActivity(workflow, step, emptyInput, fluxMetrics, stepMetrics);
+
+        Assertions.assertFalse(step.didThing(), "step body must be skipped when pre-hook forces a result");
+        Assertions.assertEquals(1, preHook.getInvocationCount());
+        Assertions.assertEquals(1, postHook.getInvocationCount(), "post hook must still run after a pre-hook override");
+        assertCompleteResult(actualResult, "PRE_FORCED", "pre forced");
+    }
+
+    @Test
+    public void testExecuteHooksAndActivity_preHookRetry_winsOverPostHookForceResult() {
+        TestPreHookReturningHookResult preHook = new TestPreHookReturningHookResult(HookResult.retryStep("pre retry"));
+        TestPostHookReturningHookResult postHook = new TestPostHookReturningHookResult(HookResult.overrideStepResult("POST_FORCED", "post forced"));
+        Workflow workflow = workflowWithStepHooks(preHook, postHook);
+        step.setStepResult(successfulStepResult());
+
+        StepResult actualResult = ActivityExecutionUtil.executeHooksAndActivity(workflow, step, emptyInput, fluxMetrics, stepMetrics);
+
+        Assertions.assertFalse(step.didThing());
+        Assertions.assertEquals(1, postHook.getInvocationCount());
+        assertRetryResult(actualResult, "pre retry");
+    }
+
+    @Test
+    public void testExecuteHooksAndActivity_preHookProceedThenForceResult_secondPreHookWins() {
+        TestPreHookReturningHookResult firstPre = new TestPreHookReturningHookResult(HookResult.proceed());
+        TestPreHookReturningHookResult secondPre = new TestPreHookReturningHookResult(HookResult.overrideStepResult("FORCED", "from second pre"));
+        TestPostStepHook postHook = new TestPostStepHook();
+        Workflow workflow = workflowWithStepHooks(firstPre, secondPre, postHook);
+        step.setStepResult(successfulStepResult());
+
+        StepResult actualResult = ActivityExecutionUtil.executeHooksAndActivity(workflow, step, emptyInput, fluxMetrics, stepMetrics);
+
+        Assertions.assertFalse(step.didThing(), "step body must be skipped when any pre-hook overrides the result");
+        Assertions.assertEquals(1, firstPre.getInvocationCount());
+        Assertions.assertEquals(1, secondPre.getInvocationCount(), "later pre-hooks must still run after an earlier non-proceed result");
+        Assertions.assertEquals(1, postHook.getPostStepHookCallCount());
+        assertCompleteResult(actualResult, "FORCED", "from second pre");
+    }
+
+    @Test
+    public void testExecuteHooksAndActivity_firstPreHookRetry_subsequentPreHookForceResult_firstWins() {
+        TestPreHookReturningHookResult firstPre = new TestPreHookReturningHookResult(HookResult.retryStep("first retry"));
+        TestPreHookReturningHookResult secondPre = new TestPreHookReturningHookResult(HookResult.overrideStepResult("FORCED", "second"));
+        Workflow workflow = workflowWithStepHooks(firstPre, secondPre);
+        step.setStepResult(successfulStepResult());
+
+        StepResult actualResult = ActivityExecutionUtil.executeHooksAndActivity(workflow, step, emptyInput, fluxMetrics, stepMetrics);
+
+        Assertions.assertFalse(step.didThing());
+        Assertions.assertEquals(1, firstPre.getInvocationCount());
+        Assertions.assertEquals(1, secondPre.getInvocationCount(), "later pre-hooks must still run after an earlier non-proceed result");
+        assertRetryResult(actualResult, "first retry");
+    }
+
+    @Test
+    public void testExecuteHooksAndActivity_firstPostHookForceResult_secondPostHookRetry_firstWins() {
+        TestPostHookReturningHookResult firstPost = new TestPostHookReturningHookResult(HookResult.overrideStepResult("FORCED", "first"));
+        TestPostHookReturningHookResult secondPost = new TestPostHookReturningHookResult(HookResult.retryStep("second retry"));
+        Workflow workflow = workflowWithStepHooks(firstPost, secondPost);
+        step.setStepResult(successfulStepResult());
+
+        StepResult actualResult = ActivityExecutionUtil.executeHooksAndActivity(workflow, step, emptyInput, fluxMetrics, stepMetrics);
+
+        Assertions.assertTrue(step.didThing());
+        Assertions.assertEquals(1, firstPost.getInvocationCount());
+        Assertions.assertEquals(1, secondPost.getInvocationCount(), "later post-hooks must still run after an earlier non-proceed result");
+        assertCompleteResult(actualResult, "FORCED", "first");
+    }
+
+    @Test
+    public void testExecuteHooksAndActivity_postHookForceResultOverridesStepRetry() {
+        TestPostHookReturningHookResult postHook = new TestPostHookReturningHookResult(HookResult.overrideStepResult("RECOVERED", "recovered"));
+        Workflow workflow = workflowWithStepHooks(postHook);
+        step.setStepResult(makeStepResult(StepResult.ResultAction.RETRY, null, "step asked for retry", Collections.emptyMap()));
+
+        StepResult actualResult = ActivityExecutionUtil.executeHooksAndActivity(workflow, step, emptyInput, fluxMetrics, stepMetrics);
+
+        Assertions.assertTrue(step.didThing());
+        Assertions.assertEquals(1, postHook.getInvocationCount());
+        assertCompleteResult(actualResult, "RECOVERED", "recovered");
+    }
+
+    @Test
+    public void testExecuteHooksAndActivity_postHookExceptionRetry_doesNotOverrideEarlierPostHookForceResult() {
+        TestPostHookReturningHookResult firstPost = new TestPostHookReturningHookResult(HookResult.overrideStepResult("FORCED", "first"));
+        WorkflowStepHook throwingPost = new TestPostHookThrowsExceptionRetryOnFailure(new RuntimeException("boom"));
+        Workflow workflow = workflowWithStepHooks(firstPost, throwingPost);
+        step.setStepResult(successfulStepResult());
+
+        StepResult actualResult = ActivityExecutionUtil.executeHooksAndActivity(workflow, step, emptyInput, fluxMetrics, stepMetrics);
+
+        Assertions.assertTrue(step.didThing());
+        Assertions.assertEquals(1, firstPost.getInvocationCount());
+        // first non-proceed result wins, even when a later hook throws and is configured to retry
+        assertCompleteResult(actualResult, "FORCED", "first");
+    }
+
+    @Test
+    public void testExecuteHooksAndActivity_postHookExceptionRetry_thenPostHookForceResult_exceptionRetryWins() {
+        WorkflowStepHook throwingPost = new TestPostHookThrowsExceptionRetryOnFailure(new RuntimeException("boom"));
+        TestPostHookReturningHookResult laterPost = new TestPostHookReturningHookResult(HookResult.overrideStepResult("FORCED", "second"));
+        Workflow workflow = workflowWithStepHooks(throwingPost, laterPost);
+        step.setStepResult(successfulStepResult());
+
+        StepResult actualResult = ActivityExecutionUtil.executeHooksAndActivity(workflow, step, emptyInput, fluxMetrics, stepMetrics);
+
+        Assertions.assertTrue(step.didThing());
+        Assertions.assertEquals(1, laterPost.getInvocationCount(), "later post-hooks must still run after an earlier hook failed with retry");
+
+        // the first non-proceed result wins; the throwing hook produced a retry result.
+        Assertions.assertEquals(StepResult.ResultAction.RETRY, actualResult.getAction());
+        Assertions.assertNull(actualResult.getResultCode());
+        Assertions.assertNotNull(actualResult.getMessage());
+        Assertions.assertTrue(actualResult.getMessage().contains("boom"));
+    }
+
+    @Test
+    public void testExecuteHooksAndActivity_postHookReturnsNonHookResultObject_isIgnored() {
+        // a non-null, non-HookResult return value must not change the step result
+        TestPostHookReturningArbitraryObject postHook = new TestPostHookReturningArbitraryObject("some string");
+        Workflow workflow = workflowWithStepHooks(postHook);
+
+        StepResult expected = successfulStepResult();
+        step.setStepResult(expected);
+
+        StepResult actualResult = ActivityExecutionUtil.executeHooksAndActivity(workflow, step, emptyInput, fluxMetrics, stepMetrics);
+
+        Assertions.assertEquals(expected, actualResult);
+        Assertions.assertEquals(1, postHook.getInvocationCount());
+    }
+
+    @Test
+    public void testExecuteHooksAndActivity_preHookForceResult_postHookCanReadForcedResultAttributes() {
+        TestPreHookReturningHookResult preHook = new TestPreHookReturningHookResult(HookResult.overrideStepResult("FORCED", "msg from pre"));
+        CapturingPostStepHook postHook = new CapturingPostStepHook();
+        Workflow workflow = workflowWithStepHooks(preHook, postHook);
+        step.setStepResult(makeStepResult(StepResult.ResultAction.COMPLETE, StepResult.SUCCEED_RESULT_CODE, "ignored", Collections.emptyMap()));
+
+        StepResult actualResult = ActivityExecutionUtil.executeHooksAndActivity(workflow, step, emptyInput, fluxMetrics, stepMetrics);
+
+        Assertions.assertFalse(step.didThing());
+
+        // post hook should observe the forced result code/message because hookInput is populated from result before post hooks run
+        Assertions.assertEquals("FORCED", postHook.getCapturedResultCode());
+        Assertions.assertEquals("msg from pre", postHook.getCapturedCompletionMessage());
+        assertCompleteResult(actualResult, "FORCED", "msg from pre");
+    }
+
+    @Test
+    public void testExecuteHooksAndActivity_workflowHookOnPreAnchor_cannotOverrideAnchorResult() {
+        TestPreHookReturningHookResult preHook = new TestPreHookReturningHookResult(HookResult.retryStep("hold up"));
+
+        WorkflowGraphBuilder builder = new WorkflowGraphBuilder(step);
+        builder.alwaysClose(step);
+        builder.addWorkflowHook(preHook);
+        Workflow workflow = new TestWorkflow(builder.build());
+
+        WorkflowStep anchorStep = workflow.getGraph().getFirstStep();
+        Assertions.assertEquals(PreWorkflowHookAnchor.class, anchorStep.getClass());
+
+        StepResult actualResult = ActivityExecutionUtil.executeHooksAndActivity(workflow, anchorStep, emptyInput, fluxMetrics, stepMetrics);
+
+        Assertions.assertEquals(1, preHook.getInvocationCount());
+        // hook return values are ignored on workflow hook anchors; the anchor returns its natural success result
+        Assertions.assertEquals(StepResult.ResultAction.COMPLETE, actualResult.getAction());
+        Assertions.assertEquals(StepResult.SUCCEED_RESULT_CODE, actualResult.getResultCode());
+    }
+
+    @Test
+    public void testExecuteHooksAndActivity_workflowHookOnPostAnchor_cannotOverrideAnchorResult() {
+        TestPostHookReturningHookResult postHook = new TestPostHookReturningHookResult(HookResult.overrideStepResult("FORCED", "from workflow hook"));
+
+        WorkflowGraphBuilder builder = new WorkflowGraphBuilder(step);
+        builder.alwaysClose(step);
+        builder.addWorkflowHook(postHook);
+        Workflow workflow = new TestWorkflow(builder.build());
+
+        WorkflowStep anchorStep = workflow.getGraph().getNodes().get(PostWorkflowHookAnchor.class).getStep();
+        Assertions.assertNotNull(anchorStep);
+
+        StepResult actualResult = ActivityExecutionUtil.executeHooksAndActivity(workflow, anchorStep, emptyInput, fluxMetrics, stepMetrics);
+
+        Assertions.assertEquals(1, postHook.getInvocationCount());
+        // hook return values are ignored on workflow hook anchors; the anchor returns its natural success result
+        Assertions.assertEquals(StepResult.ResultAction.COMPLETE, actualResult.getAction());
+        Assertions.assertEquals(StepResult.SUCCEED_RESULT_CODE, actualResult.getResultCode());
+    }
+
+    @Test
+    public void testExecuteHooksAndActivity_preHookOverrideOnPreAnchor_isIgnored() {
+        TestPreHookReturningHookResult preHook = new TestPreHookReturningHookResult(HookResult.overrideStepResult("FORCED", "from pre"));
+
+        WorkflowGraphBuilder builder = new WorkflowGraphBuilder(step);
+        builder.alwaysClose(step);
+        builder.addWorkflowHook(preHook);
+        Workflow workflow = new TestWorkflow(builder.build());
+
+        WorkflowStep anchorStep = workflow.getGraph().getFirstStep();
+        Assertions.assertEquals(PreWorkflowHookAnchor.class, anchorStep.getClass());
+
+        StepResult actualResult = ActivityExecutionUtil.executeHooksAndActivity(workflow, anchorStep, emptyInput, fluxMetrics, stepMetrics);
+
+        Assertions.assertEquals(1, preHook.getInvocationCount());
+        // pre-hook override return value must be discarded; the anchor's apply() still runs and returns success
+        Assertions.assertEquals(StepResult.ResultAction.COMPLETE, actualResult.getAction());
+        Assertions.assertEquals(StepResult.SUCCEED_RESULT_CODE, actualResult.getResultCode());
+        Assertions.assertNotEquals("FORCED", actualResult.getResultCode());
+
+        fluxMetrics.close();
+
+        // metric should reflect the anchor's natural success, not the suppressed override
+        Assertions.assertEquals(1, fluxMetrics.getCounts().get(ActivityExecutionUtil.formatCompletionResultMetricName(
+                TaskNaming.activityName(workflow, anchorStep), StepResult.SUCCEED_RESULT_CODE)).intValue());
+    }
+
+    @Test
+    public void testExecuteHooksAndActivity_postHookRetryOnPostAnchor_isIgnored() {
+        TestPostHookReturningHookResult postHook = new TestPostHookReturningHookResult(HookResult.retryStep("post says retry"));
+
+        WorkflowGraphBuilder builder = new WorkflowGraphBuilder(step);
+        builder.alwaysClose(step);
+        builder.addWorkflowHook(postHook);
+        Workflow workflow = new TestWorkflow(builder.build());
+
+        WorkflowStep anchorStep = workflow.getGraph().getNodes().get(PostWorkflowHookAnchor.class).getStep();
+        Assertions.assertNotNull(anchorStep);
+
+        StepResult actualResult = ActivityExecutionUtil.executeHooksAndActivity(workflow, anchorStep, emptyInput, fluxMetrics, stepMetrics);
+
+        Assertions.assertEquals(1, postHook.getInvocationCount());
+        // post-hook retry return value must be discarded for the post anchor; we keep the anchor's natural success
+        Assertions.assertEquals(StepResult.ResultAction.COMPLETE, actualResult.getAction());
+        Assertions.assertEquals(StepResult.SUCCEED_RESULT_CODE, actualResult.getResultCode());
+    }
+
+    @Test
+    public void testExecuteHooksAndActivity_preHookOverrideOnPreAnchor_runsLaterPreHooksAndIgnoresAllOverrides() {
+        TestPreHookReturningHookResult firstPre = new TestPreHookReturningHookResult(HookResult.retryStep("first"));
+        TestPreHookReturningHookResult secondPre = new TestPreHookReturningHookResult(HookResult.overrideStepResult("FORCED", "second"));
+
+        WorkflowGraphBuilder builder = new WorkflowGraphBuilder(step);
+        builder.alwaysClose(step);
+        builder.addWorkflowHook(firstPre);
+        builder.addWorkflowHook(secondPre);
+        Workflow workflow = new TestWorkflow(builder.build());
+
+        WorkflowStep anchorStep = workflow.getGraph().getFirstStep();
+        Assertions.assertEquals(PreWorkflowHookAnchor.class, anchorStep.getClass());
+
+        StepResult actualResult = ActivityExecutionUtil.executeHooksAndActivity(workflow, anchorStep, emptyInput, fluxMetrics, stepMetrics);
+
+        // both pre hooks must still run even though overrides are ignored on the anchor
+        Assertions.assertEquals(1, firstPre.getInvocationCount());
+        Assertions.assertEquals(1, secondPre.getInvocationCount());
+        Assertions.assertEquals(StepResult.ResultAction.COMPLETE, actualResult.getAction());
+        Assertions.assertEquals(StepResult.SUCCEED_RESULT_CODE, actualResult.getResultCode());
+    }
+
+    private Workflow workflowWithStepHooks(WorkflowStepHook... hooks) {
+        WorkflowGraphBuilder builder = new WorkflowGraphBuilder(step);
+        builder.alwaysClose(step);
+        for (WorkflowStepHook hook : hooks) {
+            builder.addStepHook(step, hook);
+        }
+        return new TestWorkflow(builder.build());
+    }
+
+    private StepResult successfulStepResult() {
+        return makeStepResult(StepResult.ResultAction.COMPLETE, StepResult.SUCCEED_RESULT_CODE, "yay", Collections.emptyMap());
+    }
+
+    private static void assertCompleteResult(StepResult actual, String expectedResultCode, String expectedMessage) {
+        Assertions.assertEquals(StepResult.ResultAction.COMPLETE, actual.getAction());
+        Assertions.assertEquals(expectedResultCode, actual.getResultCode());
+        Assertions.assertEquals(expectedMessage, actual.getMessage());
+    }
+
+    private static void assertRetryResult(StepResult actual, String expectedMessage) {
+        Assertions.assertEquals(StepResult.ResultAction.RETRY, actual.getAction());
+        Assertions.assertNull(actual.getResultCode());
+        Assertions.assertEquals(expectedMessage, actual.getMessage());
+    }
+
     private StepResult makeStepResult(StepResult.ResultAction resultAction, String stepResult, String message, Map<String, Object> output) {
         return new StepResult(resultAction, stepResult, message).withAttributes(output);
     }
@@ -789,6 +1169,87 @@ public class ActivityExecutionUtilTest {
         @StepHook(hookType = StepHook.HookType.POST, retryOnFailure = true)
         public void postStepHook() throws Throwable {
             throw ex;
+        }
+    }
+
+    public static class TestPreHookReturningHookResult implements WorkflowStepHook {
+
+        private final HookResult hookResult;
+        private int invocationCount = 0;
+
+        public TestPreHookReturningHookResult(HookResult hookResult) {
+            this.hookResult = hookResult;
+        }
+
+        @StepHook(hookType = StepHook.HookType.PRE)
+        public HookResult preStepHook() {
+            invocationCount += 1;
+            return hookResult;
+        }
+
+        public int getInvocationCount() {
+            return invocationCount;
+        }
+    }
+
+    public static class TestPostHookReturningHookResult implements WorkflowStepHook {
+
+        private final HookResult hookResult;
+        private int invocationCount = 0;
+
+        public TestPostHookReturningHookResult(HookResult hookResult) {
+            this.hookResult = hookResult;
+        }
+
+        @StepHook(hookType = StepHook.HookType.POST)
+        public HookResult postStepHook() {
+            invocationCount += 1;
+            return hookResult;
+        }
+
+        public int getInvocationCount() {
+            return invocationCount;
+        }
+    }
+
+    public static class TestPostHookReturningArbitraryObject implements WorkflowStepHook {
+
+        private final Object returnValue;
+        private int invocationCount = 0;
+
+        public TestPostHookReturningArbitraryObject(Object returnValue) {
+            this.returnValue = returnValue;
+        }
+
+        @StepHook(hookType = StepHook.HookType.POST)
+        public Object postStepHook() {
+            invocationCount += 1;
+            return returnValue;
+        }
+
+        public int getInvocationCount() {
+            return invocationCount;
+        }
+    }
+
+    public static class CapturingPostStepHook implements WorkflowStepHook {
+
+        private String capturedResultCode;
+        private String capturedCompletionMessage;
+
+        @StepHook(hookType = StepHook.HookType.POST)
+        public void postStepHook(@Attribute(StepAttributes.RESULT_CODE) String resultCode,
+                                 @Attribute(StepAttributes.ACTIVITY_COMPLETION_MESSAGE) String completionMessage) {
+            this.capturedResultCode = resultCode;
+            this.capturedCompletionMessage = completionMessage;
+        }
+
+        public String getCapturedResultCode() {
+            return capturedResultCode;
+        }
+
+        public String getCapturedCompletionMessage() {
+            return capturedCompletionMessage;
         }
     }
 }


### PR DESCRIPTION
Allows PRE and POST step hooks to override the result of a step. Overriding the result of a workflow hook produces a warning. `mvn test` and `mvn integration-test` still pass