### PR TITLE
Automatically only publish versions that haven't been published yet.

### DIFF
--- a/buildspec/build-and-publish.yml
+++ b/buildspec/build-and-publish.yml
@@ -19,4 +19,4 @@ phases:
       - echo "</server></servers></settings>" >> ~/.m2/settings.xml
   build:
     commands:
-      - mvn -Dpublishing.publishAfterStaging=true deploy -P release
+      - scripts/mvn-for-unpublished-versions.sh -Dpublishing.publishAfterStaging=true deploy -P release

--- a/buildspec/build-and-stage.yml
+++ b/buildspec/build-and-stage.yml
@@ -19,4 +19,4 @@ phases:
       - echo "</server></servers></settings>" >> ~/.m2/settings.xml
   build:
     commands:
-      - mvn deploy -P release
+      - scripts/mvn-for-unpublished-versions.sh deploy -P release

--- a/flux-common-aws/pom.xml
+++ b/flux-common-aws/pom.xml
@@ -22,10 +22,6 @@
         </license>
     </licenses>
 
-    <properties>
-        <skip.deploy>false</skip.deploy>
-    </properties>
-
     <dependencies>
         <dependency>
             <artifactId>arns</artifactId>

--- a/flux-common/pom.xml
+++ b/flux-common/pom.xml
@@ -22,10 +22,6 @@
         </license>
     </licenses>
 
-    <properties>
-        <skip.deploy>false</skip.deploy>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/flux-sfn-guice/pom.xml
+++ b/flux-sfn-guice/pom.xml
@@ -22,11 +22,6 @@
         </license>
     </licenses>
 
-    <properties>
-        <!-- Explicitly don't deploy, until we're ready to release -->
-        <skip.deploy>true</skip.deploy>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>com.google.inject</groupId>

--- a/flux-sfn-spring/pom.xml
+++ b/flux-sfn-spring/pom.xml
@@ -22,11 +22,6 @@
         </license>
     </licenses>
 
-    <properties>
-        <!-- Explicitly don't deploy, until we're ready to release -->
-        <skip.deploy>true</skip.deploy>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/flux-sfn/pom.xml
+++ b/flux-sfn/pom.xml
@@ -22,11 +22,6 @@
         </license>
     </licenses>
 
-    <properties>
-        <!-- Explicitly don't deploy, until we're ready to release -->
-        <skip.deploy>true</skip.deploy>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>commons-codec</groupId>

--- a/flux-swf-guice/pom.xml
+++ b/flux-swf-guice/pom.xml
@@ -22,10 +22,6 @@
         </license>
     </licenses>
 
-    <properties>
-        <skip.deploy>false</skip.deploy>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>com.google.inject</groupId>

--- a/flux-swf-spring/pom.xml
+++ b/flux-swf-spring/pom.xml
@@ -23,8 +23,6 @@
     </licenses>
 
     <properties>
-        <skip.deploy>false</skip.deploy>
-
         <spring.version>6.2.7</spring.version>
     </properties>
 

--- a/flux-swf/pom.xml
+++ b/flux-swf/pom.xml
@@ -22,10 +22,6 @@
         </license>
     </licenses>
 
-    <properties>
-        <skip.deploy>false</skip.deploy>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>commons-codec</groupId>

--- a/flux-testutils/pom.xml
+++ b/flux-testutils/pom.xml
@@ -22,10 +22,6 @@
         </license>
     </licenses>
 
-    <properties>
-        <skip.deploy>false</skip.deploy>
-    </properties>
-
     <dependencies>
         <!-- flux internal dependencies -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -107,10 +107,6 @@
         <checkstyle.version>10.3.4</checkstyle.version>
 
         <jre.version>11</jre.version>
-
-        <!-- Modules (including this parent pom) won't get deployed by default,
-             they'll need to override this to get deployed. -->
-        <skip.deploy>true</skip.deploy>
     </properties>
     <build>
         <plugins>
@@ -233,9 +229,6 @@
                                 </goals>
                             </execution>
                         </executions>
-                        <configuration>
-                            <skipSource>${skip.deploy}</skipSource>
-                        </configuration>
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
@@ -249,9 +242,6 @@
                                 </goals>
                             </execution>
                         </executions>
-                        <configuration>
-                            <skip>${skip.deploy}</skip>
-                        </configuration>
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
@@ -266,7 +256,6 @@
                             </execution>
                         </executions>
                         <configuration>
-                            <skip>${skip.deploy}</skip>
                             <signer>bc</signer>
                             <keyFingerprintEnvName>GPG_KEY_ID</keyFingerprintEnvName>
                             <keyEnvName>GPG_PRIVATE_KEY</keyEnvName>
@@ -283,7 +272,6 @@
                         <configuration>
                             <publishingServerId>central</publishingServerId>
                             <autoPublish>${publishing.publishAfterStaging}</autoPublish>
-                            <skipPublishing>${skip.deploy}</skipPublishing>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/scripts/find-modules-to-publish.sh
+++ b/scripts/find-modules-to-publish.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+TO_PUBLISH=()
+
+check_module_published() {
+  local module=$1
+
+  if [ ! -f "${module}/pom.xml" ]; then
+    echo "Could not find ${module}/pom.xml"
+    exit 1
+  fi
+
+  local filename="/tmp/${module}-effective-pom.xml"
+  # dumps the effective pom for this module, and ignores the log output that isn't the xml
+  mvn help:effective-pom -pl :${module} -B | grep "^\s*<" > $filename
+
+  local group_id=$(xmllint --xpath "string(/*[local-name()='project']/*[local-name()='groupId'])" $filename)
+  local artifact_id=$(xmllint --xpath "string(/*[local-name()='project']/*[local-name()='artifactId'])" $filename)
+  local version=$(xmllint --xpath "string(/*[local-name()='project']/*[local-name()='version'])" $filename)
+
+  #echo "Checking ${group_id//./\/}/${artifact_id}/${version}"
+
+  local md_url="https://repo1.maven.org/maven2/${group_id//./\/}/${artifact_id}/maven-metadata.xml"
+  local md_file="/tmp/${module}-md.xml"
+
+  wget -q $md_url -O /tmp/${module}-md.xml
+  if [ $? -ne 0 ] ; then
+    #echo "$artifact_id appears to be a new package, including $version for publishing."
+    TO_PUBLISH+=(":${module}")
+  elif ! xmllint --xpath "/metadata/versioning/versions/version[text()='${version}']" $md_file > /dev/null; then
+    TO_PUBLISH+=(":${module}")
+    #echo "Including $version for publishing."
+  #else
+    #echo "$version is already published."
+  fi
+
+  rm $md_file
+  rm $filename
+}
+
+check_module_published 'flux-common'
+check_module_published 'flux-common-aws'
+check_module_published 'flux-testutils'
+
+check_module_published 'flux-swf'
+check_module_published 'flux-swf-guice'
+check_module_published 'flux-swf-spring'
+
+#sfn not ready for release yet
+#check_module_published 'flux-sfn'
+#check_module_published 'flux-sfn-guice'
+#check_module_published 'flux-sfn-spring'
+
+if [ "${#TO_PUBLISH[@]}" == 0 ]; then
+    echo "Nothing to publish"
+    exit 1
+fi
+
+echo $(IFS=, ; echo "${TO_PUBLISH[*]}")
+exit 0

--- a/scripts/mvn-for-unpublished-versions.sh
+++ b/scripts/mvn-for-unpublished-versions.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+MODULES=$(scripts/find-modules-to-publish.sh)
+if [ ! $? -eq 0 ]; then
+  echo "No unpublished module versions found, skipping mvn execution."
+  exit 0
+fi
+
+mvn -pl "$MODULES" -am "$@"


### PR DESCRIPTION
When I did the 2.1.1 release for flux-common, flux-testutils, and flux-swf, I had to manually publish after removing the other packages from the zip file produced by `mvn deploy -P release`.

This change makes the release build skip packaging, signing, staging, and deploying for any module that has a version that has already been published.

The command that `mvn-for-unpublished-versions.sh` ends up running looks like this:

`mvn -pl :flux-common,:flux-testutils,:flux-swf -am deploy -P release`

`-pl` limits the deploy to include the listed modules, and `-am` compiles (but otherwise excludes) any other local dependencies required by the listed modules.

This does mean the integration tests no longer run during the actual release; this is fine since we automatically trigger integration test runs for any new commits, whereas releases are triggered manually after the automatic integration test run has succeeded, and we may end up chaining the two together for fully automated releases.

Other notes:
- I verified that the codebuild image we're using has `xmllint` installed by default; it's the only new tool required by this change.
- I've run the pieces of this individually, but never all together "for real", because we don't have any new versions to publish right now. I'm planning to budget some extra time for troubleshooting next time we do a release.


